### PR TITLE
core.refactor binary stream

### DIFF
--- a/src/core/BaseManipulation.cpp
+++ b/src/core/BaseManipulation.cpp
@@ -691,10 +691,10 @@ BaseManipulation::deletePorts(){
 /*!
  * It sets the buffer stored in an input port of the object.
  * \param[in] port ID of the input port.
- * \param[in] input Reference to bitpit::IBinaryStream to store in m_ibuffer member of the port.
+ * \param[in] input Reference to mimmo::IBinaryStream to store in m_ibuffer member of the port.
  */
 void
-BaseManipulation::setBufferIn(PortID port, bitpit::IBinaryStream& input){
+BaseManipulation::setBufferIn(PortID port, mimmo::IBinaryStream& input){
     m_portIn[port]->m_ibuffer = input;
 }
 

--- a/src/core/BaseManipulation.hpp
+++ b/src/core/BaseManipulation.hpp
@@ -248,7 +248,7 @@ protected:
     template<typename T, typename O>
     bool    createPortIn(O* obj, void (O::*setVar_)(T), PortID portR, bool mandatory = false, int family = 0);
 
-    void    setBufferIn(PortID port, bitpit::IBinaryStream& input);
+    void    setBufferIn(PortID port, mimmo::IBinaryStream& input);
     void    readBufferIn(PortID port);
     void    cleanBufferIn(PortID port);
 

--- a/src/core/InOut.cpp
+++ b/src/core/InOut.cpp
@@ -25,13 +25,46 @@
 #include "MimmoNamespace.hpp"
 #include "BaseManipulation.hpp"
 
+namespace mimmo{
+    /*!
+        base constructor
+    */
+    IBinaryStream::IBinaryStream(void) : bitpit::IBinaryStream(){};
+    /*!
+        custom constructor
+        @param[in] size of the buffer
+    */
+    IBinaryStream::IBinaryStream(std::size_t size) : bitpit::IBinaryStream(size){};
+    /*!
+        custom constructor
+        @param[in] buffer pointer to buffer
+        @param[in] size size of the buffer
+    */
+    IBinaryStream::IBinaryStream(const char *buffer, std::size_t size) : bitpit::IBinaryStream(buffer,size){};
+    /*!
+        custom constructor
+        @param[in] buffer as vector of char
+    */
+    IBinaryStream::IBinaryStream(const std::vector<char> &buffer): bitpit::IBinaryStream(buffer){};
+
+    /*!
+        base constructor
+    */
+    OBinaryStream::OBinaryStream(): bitpit::OBinaryStream(){};
+    /*!
+        custom constructor
+        @param[in] size size of the buffer
+    */
+    OBinaryStream::OBinaryStream(std::size_t size): bitpit::OBinaryStream(size){};
+};
+
 /*!
 *	Output stream operator for mimmo::ShapeType enum
 *	\param[in] buffer is the output stream
 *	\param[in] var is the element to be streamed
 *	\result Returns the same output stream received in input.
 */
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const mimmo::ShapeType &var)
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream  &buffer, const mimmo::ShapeType &var)
 {
     buffer << static_cast<int> (var);
     return buffer;
@@ -44,7 +77,7 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const mimmo::S
 *	\param[in] var is the element to be streamed
 *	\result Returns the same input stream received in input.
 */
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, mimmo::ShapeType &var)
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buffer, mimmo::ShapeType &var)
 {
     int val;
     buffer >> val;
@@ -58,7 +91,7 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, mimmo::ShapeTyp
 *	\param[in] var is the element to be streamed
 *	\result Returns the same output stream received in input.
 */
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const mimmo::CoordType &var)
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream  &buffer, const mimmo::CoordType &var)
 {
     buffer << static_cast<int> (var);
     return buffer;
@@ -71,7 +104,7 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const mimmo::C
 *	\param[in] var is the element to be streamed
 *	\result Returns the same input stream received in input.
 */
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, mimmo::CoordType &var)
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buffer, mimmo::CoordType &var)
 {
     int val;
     buffer >> val;
@@ -85,7 +118,7 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, mimmo::CoordTyp
 *	\param[in] var is the element to be streamed
 *	\result Returns the same input stream received in input.
 */
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, mimmo::FileDataInfo&  var){
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buffer, mimmo::FileDataInfo&  var){
 
     buffer >> var.ftype;
     buffer >> var.fdir;
@@ -100,9 +133,11 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, mimmo::FileData
 *	\param[in] var is the element to be streamed
 *	\result Returns the same output stream received in input.
 */
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const mimmo::FileDataInfo& var){
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buffer, const mimmo::FileDataInfo& var){
 
-    buffer<<var.ftype<<var.fdir<<var.fname;
+    buffer<<var.ftype;
+    buffer<<var.fdir;
+    buffer<<var.fname;
     return buffer;
 
 
@@ -114,7 +149,7 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const mimmo::Fi
     \param[in] element is the element to be streamed
     \result Returns the same output stream received in input.
 */
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const std::string& element){
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buffer, const std::string& element){
 
     // Copy until +1 size term, the last one is the end character (old version)
 	// std::vector<char> inputss(element.c_str(), element.c_str()+element.size()+1);
@@ -135,7 +170,7 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const std::stri
     \param[in] element is the element to be streamed
     \result Returns the same input stream received in input.
 */
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, std::string& element){
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buffer, std::string& element){
 
 	std::size_t nids;
     buffer >> nids;
@@ -143,10 +178,12 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, std::string& el
     for (std::size_t i = 0; i < nids; ++i){
         buffer >> inputss[i];
     }
+
     // Copy until -1 term, the last one is the end character (old version)
     //  element = std::string(inputss.begin(), inputss.end()-1);
 
     element = std::string(inputss.begin(), inputss.end());
+
 
     return buffer;
 
@@ -304,7 +341,7 @@ void
 mimmo::PortOut::exec(){
     if (m_objLink.size() > 0){
         writeBuffer();
-        bitpit::IBinaryStream input(m_obuffer.data(), m_obuffer.getSize());
+        mimmo::IBinaryStream input(m_obuffer.data(), m_obuffer.getSize());
         cleanBuffer();
         for (int j=0; j<(int)m_objLink.size(); j++){
             if (m_objLink[j] != NULL){

--- a/src/core/InOut.hpp
+++ b/src/core/InOut.hpp
@@ -55,6 +55,33 @@ typedef mimmo::MimmoPiercedVector<darray3E>  dmpvecarr3E;   /**< mimmo custom ty
  * \}
  */
 
+
+ /*!
+     @class IBinaryStream
+     @ingroup binaryStream
+     @brief mimmo custom derivation of bitpit IBinaryStream (see relative doc)
+ */
+ class IBinaryStream : public bitpit::IBinaryStream {
+
+ public:
+     IBinaryStream(void);
+     IBinaryStream(std::size_t size);
+     IBinaryStream(const char *buffer, std::size_t size);
+     IBinaryStream(const std::vector<char> &buffer);
+ };
+
+ /*!
+     @class OBinaryStream
+     @ingroup binaryStream
+     @brief mimmo custom derivation of bitpit OBinaryStream (see relative doc)
+ */
+ class OBinaryStream : public bitpit::OBinaryStream {
+
+ public:
+     OBinaryStream();
+     OBinaryStream(std::size_t size);
+ };
+
 /*!
 * \class DataType
 * \brief Class DataType defines the container and the type of data communicated by ports.
@@ -105,7 +132,7 @@ public:
 class PortOut{
 public:
     //members
-    bitpit::OBinaryStream           m_obuffer;	/**<Output buffer to communicate data.*/
+    mimmo::OBinaryStream            m_obuffer;	/**<Output buffer to communicate data.*/
     std::vector<BaseManipulation*>  m_objLink;	/**<Outputs object to which communicate the data.*/
     std::vector<PortID>             m_portLink;	/**<ID of the input ports of the linked objects.*/
     DataType                        m_datatype;	/**<TAG of type of data communicated.*/
@@ -210,7 +237,7 @@ public:
 class PortIn{
 public:
     //members
-    bitpit::IBinaryStream               m_ibuffer;          /**<input buffer to recover data.*/
+    mimmo::IBinaryStream                m_ibuffer;          /**<input buffer to recover data.*/
     std::vector<BaseManipulation*>      m_objLink;          /**<Input objects from which recover the data. */
     DataType                            m_datatype;         /**<TAG of type of data communicated.*/
     bool                                m_mandatory;        /**<Does the port have to be mandatorily linked?.*/
@@ -300,53 +327,53 @@ public:
  * \{
  */
 //BASIC TYPES
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buf, mimmo::CoordType& element);
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buf, const mimmo::CoordType& element);
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buf, mimmo::CoordType& element);
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buf, const mimmo::CoordType& element);
 
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buf, mimmo::ShapeType& element);
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buf, const mimmo::ShapeType& element);
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buf, mimmo::ShapeType& element);
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buf, const mimmo::ShapeType& element);
 
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buf, mimmo::FileDataInfo&  element);
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buf, const mimmo::FileDataInfo& element);
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buf, mimmo::FileDataInfo&  element);
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buf, const mimmo::FileDataInfo& element);
 
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buf, std::string & element);
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buf, const std::string & element);
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buf, std::string & element);
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buf, const std::string & element);
 
 //TEMPLATE STRUCTURES
-template<typename T>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buf, T& element);
-template<typename T>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buf, const T& element);
+// template<typename T>
+// mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buf, T& element);
+// template<typename T>
+// mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buf, const T& element);
 
 template<typename T>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buf,std::vector<T>& element);
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buf,std::vector<T>& element);
 template<typename T>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buf, const std::vector<T>& element);
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buf, const std::vector<T>& element);
 
 template<typename T, std::size_t d>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buf, std::array<T,d>& element);
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buf, std::array<T,d>& element);
 template<typename T, std::size_t d>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buf, const std::array<T,d>& element);
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buf, const std::array<T,d>& element);
 
 template<typename T, typename Q>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buf, std::pair<T, Q>& element);
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buf, std::pair<T, Q>& element);
 template<typename T, typename Q>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buf, const std::pair<T, Q>& element);
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buf, const std::pair<T, Q>& element);
 
 template<typename T, typename Q>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buf, std::unordered_map<T, Q>&  element);
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buf, std::unordered_map<T, Q>&  element);
 template<typename T, typename Q>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buf, const std::unordered_map<T, Q >& element);
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buf, const std::unordered_map<T, Q >& element);
 
 template<typename T, typename Q>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buf, std::map<T,Q>& element);
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buf, std::map<T,Q>& element);
 template<typename T, typename Q>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buf, const std::map<T, Q>& element);
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buf, const std::map<T, Q>& element);
 
 template<typename T>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buf,mimmo::MimmoPiercedVector<T>& element);
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buf,mimmo::MimmoPiercedVector<T>& element);
 template<typename T>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buf, const mimmo::MimmoPiercedVector<T>& element);
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buf, const mimmo::MimmoPiercedVector<T>& element);
 
 /*!
  *\}

--- a/src/core/InOut.tpp
+++ b/src/core/InOut.tpp
@@ -274,7 +274,7 @@ PortInT<T, O>::readBuffer(){
     \result Returns the same output stream received in input.
 */
 template<typename T>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const std::vector<T> &var)
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream  &buffer, const std::vector<T> &var)
 {
     std::size_t nP = var.size();
     buffer << nP;
@@ -292,7 +292,7 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const std::vec
     \result Returns the same input stream received in input.
 */
 template<typename T>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, std::vector<T> &var)
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buffer, std::vector<T> &var)
 {
     std::size_t nP;
     buffer >> nP;
@@ -311,7 +311,7 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, std::vector<T> 
 *	\result Returns the same output stream received in input.
 */
 template <typename T, std::size_t d>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const std::array<T,d> &var)
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream  &buffer, const std::array<T,d> &var)
 {
     for(std::size_t i=0; i<d; ++i){
         buffer << var[i];
@@ -327,7 +327,7 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream  &buffer, const std::arr
 *	\result Returns the same input stream received in input.
 */
 template <typename T, std::size_t d>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, std::array<T,d> &var)
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buffer, std::array<T,d> &var)
 {
     for(std::size_t i=0; i<d; ++i){
         buffer >> var[i];
@@ -342,11 +342,12 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, std::array<T,d>
 *	\result Returns the same input stream received in input.
 */
 template<typename T, typename Q>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, std::pair<T, Q>& element){
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buffer, std::pair<T, Q>& element){
 
     T geo;
     Q data;
-    buffer >> geo >> data ;
+    buffer >> geo;
+    buffer >> data;
     element = std::make_pair(geo, data);
     return buffer;
 };
@@ -358,9 +359,10 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, std::pair<T, Q>
 *	\result Returns the same input stream received in input.
 */
 template<typename T, typename Q>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const std::pair<T, Q>& element){
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buffer, const std::pair<T, Q>& element){
 
-    buffer<<element.first<<element.second;
+    buffer<<element.first;
+    buffer<<element.second;
     return buffer;
 };
 
@@ -372,14 +374,15 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const std::pair
 *	\result Returns the same input stream received in input.
 */
 template<typename T, typename Q>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer,std::unordered_map<T, Q >&  var){
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buffer,std::unordered_map<T, Q >&  var){
 
     T key;
     Q value;
     std::size_t nP;
     buffer >> nP;
     for (std::size_t i = 0; i < nP; ++i) {
-        buffer >> key>> value;
+        buffer >> key;
+        buffer >> value;
         var[key] = value;
     }
     return buffer;
@@ -392,12 +395,13 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer,std::unordered_m
 *	\result Returns the same output stream received in input.
 */
 template<typename T, typename Q>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const std::unordered_map<T, Q>& var){
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buffer, const std::unordered_map<T, Q>& var){
 
     std::size_t nP = var.size();
     buffer << nP;
     for (auto & ee : var) {
-        buffer << ee.first<<ee.second;
+        buffer << ee.first;
+        buffer <<ee.second;
     }
     return buffer;
 };
@@ -409,14 +413,15 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const std::unor
 *	\result Returns the same input stream received in input.
 */
 template<typename T, typename Q>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer,std::map<T, Q >&  var){
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buffer,std::map<T, Q >&  var){
 
     T key;
     Q value;
     std::size_t nP;
     buffer >> nP;
     for (std::size_t i = 0; i < nP; ++i) {
-        buffer >> key>> value;
+        buffer >> key;
+        buffer >> value;
         var[key] = value;
     }
     return buffer;
@@ -429,12 +434,13 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer,std::map<T, Q >&
 *	\result Returns the same output stream received in input.
 */
 template<typename T, typename Q>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const std::map<T, Q>& var){
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buffer, const std::map<T, Q>& var){
 
     std::size_t nP = var.size();
     buffer << nP;
-    for (std::pair<T,Q> & ee : var) {
-        buffer << ee.first<<ee.second;
+    for (auto & ee : var) {
+        buffer << ee.first;
+        buffer <<ee.second;
     }
     return buffer;
 };
@@ -446,13 +452,12 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const std::map<
 * \result Returns the same output stream received in input.
 */
 template< typename T>
-bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, mimmo::MimmoPiercedVector<T>& element){
+mimmo::IBinaryStream& operator>>(mimmo::IBinaryStream &buffer, mimmo::MimmoPiercedVector<T>& element){
 
     element.clear();
     mimmo::MimmoObject* geo;
     buffer >> geo;
     element.setGeometry(geo);
-
     std::string name;
     // std::size_t length;
     // buffer >> length;
@@ -467,8 +472,10 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, mimmo::MimmoPie
     int loc_;
     buffer >> loc_;
     element.setDataLocation(static_cast<mimmo::MPVLocation>(loc_));
+
     std::size_t nP;
     buffer >> nP;
+
     T val;
     long int id;
     for (std::size_t i = 0; i < nP; ++i) {
@@ -486,7 +493,7 @@ bitpit::IBinaryStream& operator>>(bitpit::IBinaryStream &buffer, mimmo::MimmoPie
 * \result Returns the same output stream received in input.
 */
 template<typename T>
-bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const mimmo::MimmoPiercedVector<T>& element){
+mimmo::OBinaryStream& operator<<(mimmo::OBinaryStream &buffer, const mimmo::MimmoPiercedVector<T>& element){
 
     buffer << element.getGeometry();
 
@@ -502,7 +509,8 @@ bitpit::OBinaryStream& operator<<(bitpit::OBinaryStream &buffer, const mimmo::Mi
     buffer << (std::size_t)element.size();
     auto itE = element.cend();
     for (auto it=element.cbegin(); it!=itE; it++){
-        buffer << it.getId()<<*it;
+        buffer << it.getId();
+        buffer << *it;
     }
     return buffer;
 };

--- a/src/iocgns/IOCGNS.cpp
+++ b/src/iocgns/IOCGNS.cpp
@@ -1888,11 +1888,11 @@ void IOCGNS::communicateAllProcsStoredBC(){
     if(m_rank == 0){
 
         //create char output data buffer and reverse data into it.
-        bitpit::OBinaryStream dataBuffer_pidtolisttype;
-        bitpit::OBinaryStream dataBuffer_pidtobc;
-        bitpit::OBinaryStream dataBuffer_zonetobndpid;
-        bitpit::OBinaryStream dataBuffer_bcpidnames;
-        bitpit::OBinaryStream dataBuffer_zonepidnames;
+        mimmo::OBinaryStream dataBuffer_pidtolisttype;
+        mimmo::OBinaryStream dataBuffer_pidtobc;
+        mimmo::OBinaryStream dataBuffer_zonetobndpid;
+        mimmo::OBinaryStream dataBuffer_bcpidnames;
+        mimmo::OBinaryStream dataBuffer_zonepidnames;
 
         dataBuffer_pidtobc << m_storedBC->mcg_pidtobc;
         dataBuffer_zonetobndpid << m_storedBC->mcg_zonetobndpid;
@@ -1928,27 +1928,27 @@ void IOCGNS::communicateAllProcsStoredBC(){
         long dbs1,dbs2, dbs3,dbs4, dbs5;
 
         MPI_Recv(&dbs1, 1, MPI_LONG, 0, 100, m_communicator, MPI_STATUS_IGNORE);
-        bitpit::IBinaryStream dataBuffer_pidtobc(dbs1);
+        mimmo::IBinaryStream dataBuffer_pidtobc(dbs1);
         MPI_Recv(dataBuffer_pidtobc.data(), dataBuffer_pidtobc.getSize(), MPI_CHAR, 0, 110, m_communicator, MPI_STATUS_IGNORE);
         dataBuffer_pidtobc >> m_storedBC->mcg_pidtobc;
 
         MPI_Recv(&dbs2, 1, MPI_LONG, 0, 200, m_communicator, MPI_STATUS_IGNORE);
-        bitpit::IBinaryStream dataBuffer_zonetobndpid(dbs2);
+        mimmo::IBinaryStream dataBuffer_zonetobndpid(dbs2);
         MPI_Recv(dataBuffer_zonetobndpid.data(), dataBuffer_zonetobndpid.getSize(), MPI_CHAR, 0, 210, m_communicator, MPI_STATUS_IGNORE);
         dataBuffer_zonetobndpid >> m_storedBC->mcg_zonetobndpid;
 
         MPI_Recv(&dbs3, 1, MPI_LONG, 0, 300, m_communicator, MPI_STATUS_IGNORE);
-        bitpit::IBinaryStream dataBuffer_pidtolisttype(dbs3);
+        mimmo::IBinaryStream dataBuffer_pidtolisttype(dbs3);
         MPI_Recv(dataBuffer_pidtolisttype.data(), dataBuffer_pidtolisttype.getSize(), MPI_CHAR, 0, 310, m_communicator, MPI_STATUS_IGNORE);
         dataBuffer_pidtolisttype >> m_storedBC->mcg_pidtobc;
 
         MPI_Recv(&dbs4, 1, MPI_LONG, 0, 400, m_communicator, MPI_STATUS_IGNORE);
-        bitpit::IBinaryStream dataBuffer_bcpidnames(dbs4);
+        mimmo::IBinaryStream dataBuffer_bcpidnames(dbs4);
         MPI_Recv(dataBuffer_bcpidnames.data(), dataBuffer_bcpidnames.getSize(), MPI_CHAR, 0, 410, m_communicator, MPI_STATUS_IGNORE);
         dataBuffer_bcpidnames >> m_storedBC->mcg_bcpidnames;
 
         MPI_Recv(&dbs5, 1, MPI_LONG, 0, 500, m_communicator, MPI_STATUS_IGNORE);
-        bitpit::IBinaryStream dataBuffer_zonepidnames(dbs5);
+        mimmo::IBinaryStream dataBuffer_zonepidnames(dbs5);
         MPI_Recv(dataBuffer_zonepidnames.data(), dataBuffer_zonepidnames.getSize(), MPI_CHAR, 0, 510, m_communicator, MPI_STATUS_IGNORE);
         dataBuffer_zonepidnames >> m_storedBC->mcg_zonepidnames;
 

--- a/src/iogeneric/GenericInput.tpp
+++ b/src/iogeneric/GenericInput.tpp
@@ -366,7 +366,7 @@ GenericInput::sendReadDataToAllProcs(T & dataTC){
     if(m_rank == 0){
 
         //create char output data buffer and reverse data into it.
-        bitpit::OBinaryStream dataBuffer;
+        mimmo::OBinaryStream dataBuffer;
         dataBuffer << dataTC;
         long dataBufferSize = dataBuffer.getSize();
         //Send data to all other procs
@@ -379,7 +379,7 @@ GenericInput::sendReadDataToAllProcs(T & dataTC){
 
         long dataBufferSize;
         MPI_Recv(&dataBufferSize, 1, MPI_LONG, 0, 100, m_communicator, MPI_STATUS_IGNORE);
-        bitpit::IBinaryStream dataBuffer(dataBufferSize);
+        mimmo::IBinaryStream dataBuffer(dataBufferSize);
         MPI_Recv(dataBuffer.data(), dataBuffer.getSize(), MPI_CHAR, 0, 110, m_communicator, MPI_STATUS_IGNORE);
 
         dataBuffer >> dataTC;
@@ -523,7 +523,7 @@ GenericInputMPVData::sendReadDataToAllProcs(MimmoPiercedVector<T> & dataTC){
 
     if(m_rank == 0){
 
-        bitpit::OBinaryStream dataBuffer;
+        mimmo::OBinaryStream dataBuffer;
         //create char output data buffer and reverse data into it.
         dataBuffer << dataTC;
         long dataBufferSize = dataBuffer.getSize();
@@ -539,7 +539,7 @@ GenericInputMPVData::sendReadDataToAllProcs(MimmoPiercedVector<T> & dataTC){
         long dataBufferSize;
         MPI_Recv(&dataBufferSize, 1, MPI_LONG, 0, 100, m_communicator, MPI_STATUS_IGNORE);
 
-        bitpit::IBinaryStream dataBuffer(dataBufferSize);
+        mimmo::IBinaryStream dataBuffer(dataBufferSize);
         MPI_Recv(dataBuffer.data(), dataBuffer.getSize(), MPI_CHAR, 0, 110, m_communicator, MPI_STATUS_IGNORE);
 
         dataBuffer >> dataTC;

--- a/src/iogeneric/GenericOutput.tpp
+++ b/src/iogeneric/GenericOutput.tpp
@@ -299,7 +299,7 @@ GenericOutputMPVData::collectDataFromAllProcs(MimmoPiercedVector<T> & locdata, M
         for (int sendRank=1; sendRank<m_nprocs; sendRank++){
             long dataBufferSize;
             MPI_Recv(&dataBufferSize, 1, MPI_LONG, sendRank, 100, m_communicator, MPI_STATUS_IGNORE);
-            bitpit::IBinaryStream dataBuffer(dataBufferSize);
+            mimmo::IBinaryStream dataBuffer(dataBufferSize);
             MPI_Recv(dataBuffer.data(), dataBuffer.getSize(), MPI_CHAR, sendRank, 110, m_communicator, MPI_STATUS_IGNORE);
 
             //reverse in temp
@@ -316,7 +316,7 @@ GenericOutputMPVData::collectDataFromAllProcs(MimmoPiercedVector<T> & locdata, M
         //hey 0, your job is done.
     }else{
 
-        bitpit::OBinaryStream dataBuffer;
+        mimmo::OBinaryStream dataBuffer;
         dataBuffer << locdata;
         long dataBufferSize = dataBuffer.getSize();
         //Send data to rank 0

--- a/src/parallel/Partition.cpp
+++ b/src/parallel/Partition.cpp
@@ -682,14 +682,14 @@ Partition::serialize(MimmoObject* & geometry, bool isBoundary)
 			long vertexBufferSize;
 			MPI_Recv(&vertexBufferSize, 1, MPI_LONG, sendRank, 100, m_communicator, MPI_STATUS_IGNORE);
 
-			bitpit::IBinaryStream vertexBuffer(vertexBufferSize);
+			mimmo::IBinaryStream vertexBuffer(vertexBufferSize);
 			MPI_Recv(vertexBuffer.data(), vertexBuffer.getSize(), MPI_CHAR, sendRank, 110, m_communicator, MPI_STATUS_IGNORE);
 
 			// Cell data
 			long cellBufferSize;
 			MPI_Recv(&cellBufferSize, 1, MPI_LONG, sendRank, 200, m_communicator, MPI_STATUS_IGNORE);
 
-			bitpit::IBinaryStream cellBuffer(cellBufferSize);
+			mimmo::IBinaryStream cellBuffer(cellBufferSize);
 			MPI_Recv(cellBuffer.data(), cellBuffer.getSize(), MPI_CHAR, sendRank, 210, m_communicator, MPI_STATUS_IGNORE);
 
 			// There are no duplicate in the received vertices, but some of them may
@@ -739,7 +739,7 @@ Partition::serialize(MimmoObject* & geometry, bool isBoundary)
 	    //
 	    // Send vertex data
 	    //
-	    bitpit::OBinaryStream vertexBuffer;
+	    mimmo::OBinaryStream vertexBuffer;
 	    long vertexBufferSize = 0;
 	    long nVerticesToCommunicate = 0;
 
@@ -767,7 +767,7 @@ Partition::serialize(MimmoObject* & geometry, bool isBoundary)
 	    //
 	    // Send cell data
 	    //
-	    bitpit::OBinaryStream cellBuffer;
+	    mimmo::OBinaryStream cellBuffer;
 	    long cellBufferSize = 0;
 	    long nCellsToCommunicate = 0;
 

--- a/src/propagators/PropagateField.cpp
+++ b/src/propagators/PropagateField.cpp
@@ -741,14 +741,14 @@ void PropagateVectorField::initializeSlipSurface(){
 				long vertexBufferSize;
 				MPI_Recv(&vertexBufferSize, 1, MPI_LONG, sendRank, 100, m_communicator, MPI_STATUS_IGNORE);
 
-				bitpit::IBinaryStream vertexBuffer(vertexBufferSize);
+				mimmo::IBinaryStream vertexBuffer(vertexBufferSize);
 				MPI_Recv(vertexBuffer.data(), vertexBuffer.getSize(), MPI_CHAR, sendRank, 110, m_communicator, MPI_STATUS_IGNORE);
 
 				// Cell data
 				long cellBufferSize;
 				MPI_Recv(&cellBufferSize, 1, MPI_LONG, sendRank, 200, m_communicator, MPI_STATUS_IGNORE);
 
-				bitpit::IBinaryStream cellBuffer(cellBufferSize);
+				mimmo::IBinaryStream cellBuffer(cellBufferSize);
 				MPI_Recv(cellBuffer.data(), cellBuffer.getSize(), MPI_CHAR, sendRank, 210, m_communicator, MPI_STATUS_IGNORE);
 
 				// There are no duplicate in the received vertices, but some of them may
@@ -794,7 +794,7 @@ void PropagateVectorField::initializeSlipSurface(){
 				//
 				// Send vertex data
 				//
-				bitpit::OBinaryStream vertexBuffer;
+				mimmo::OBinaryStream vertexBuffer;
 				long vertexBufferSize = 0;
 				long nVerticesToCommunicate = 0;
 
@@ -829,7 +829,7 @@ void PropagateVectorField::initializeSlipSurface(){
 				//
 				// Send cell data
 				//
-				bitpit::OBinaryStream cellBuffer;
+				mimmo::OBinaryStream cellBuffer;
 				long cellBufferSize = 0;
 				long nCellsToCommunicate = 0;
 
@@ -953,7 +953,7 @@ std::unique_ptr<MimmoPiercedVector<std::array<double,3> > >
 	//Send my own and receive deformations by other.
 
     //prepare my own send buffer.
-    bitpit::OBinaryStream myrankDataBuffer;
+    mimmo::OBinaryStream myrankDataBuffer;
     myrankDataBuffer << *(mpvres.get());
     long myrankDataBufferSize = myrankDataBuffer.getSize();
 
@@ -963,7 +963,7 @@ std::unique_ptr<MimmoPiercedVector<std::array<double,3> > >
             // receive data from other ranks.
 			long defBufferSize;
 			MPI_Recv(&defBufferSize, 1, MPI_LONG, sendRank, 900, m_communicator, MPI_STATUS_IGNORE);
-			bitpit::IBinaryStream defBuffer(defBufferSize);
+			mimmo::IBinaryStream defBuffer(defBufferSize);
 			MPI_Recv(defBuffer.data(), defBuffer.getSize(), MPI_CHAR, sendRank, 910, m_communicator, MPI_STATUS_IGNORE);
 
             MimmoPiercedVector<std::array<double,3>> temp;

--- a/src/propagators/PropagateField.tpp
+++ b/src/propagators/PropagateField.tpp
@@ -581,14 +581,14 @@ void PropagateField<NCOMP>::initializeDumpingSurface(){
     			long vertexBufferSize;
     			MPI_Recv(&vertexBufferSize, 1, MPI_LONG, sendRank, 100, m_communicator, MPI_STATUS_IGNORE);
 
-    			bitpit::IBinaryStream vertexBuffer(vertexBufferSize);
+    			mimmo::IBinaryStream vertexBuffer(vertexBufferSize);
     			MPI_Recv(vertexBuffer.data(), vertexBuffer.getSize(), MPI_CHAR, sendRank, 110, m_communicator, MPI_STATUS_IGNORE);
 
     			// Cell data
     			long cellBufferSize;
     			MPI_Recv(&cellBufferSize, 1, MPI_LONG, sendRank, 200, m_communicator, MPI_STATUS_IGNORE);
 
-    			bitpit::IBinaryStream cellBuffer(cellBufferSize);
+    			mimmo::IBinaryStream cellBuffer(cellBufferSize);
     			MPI_Recv(cellBuffer.data(), cellBuffer.getSize(), MPI_CHAR, sendRank, 210, m_communicator, MPI_STATUS_IGNORE);
 
     			// There are no duplicate in the received vertices, but some of them may
@@ -634,7 +634,7 @@ void PropagateField<NCOMP>::initializeDumpingSurface(){
     			//
     			// Send vertex data
     			//
-    			bitpit::OBinaryStream vertexBuffer;
+    			mimmo::OBinaryStream vertexBuffer;
     			long vertexBufferSize = 0;
     			long nVerticesToCommunicate = 0;
 
@@ -669,7 +669,7 @@ void PropagateField<NCOMP>::initializeDumpingSurface(){
     			//
     			// Send cell data
     			//
-    			bitpit::OBinaryStream cellBuffer;
+    			mimmo::OBinaryStream cellBuffer;
     			long cellBufferSize = 0;
     			long nCellsToCommunicate = 0;
 

--- a/test/core/test_core_00000.cpp
+++ b/test/core/test_core_00000.cpp
@@ -33,7 +33,7 @@
 
 int test1() {
 
-    bitpit::OBinaryStream outbuf;
+    mimmo::OBinaryStream outbuf;
 
     //1. testing a vector of simple type double.
     {
@@ -41,7 +41,7 @@ int test1() {
 
         outbuf.seekg(0); //clean it
         outbuf << input;
-        bitpit::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
+        mimmo::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
         std::vector<double>output;
         inbuf>>output;
 
@@ -68,7 +68,7 @@ int test1() {
 
         outbuf.seekg(0); //clean it
         outbuf << input_ptr;
-        bitpit::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
+        mimmo::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
         std::vector<double*>output;
         inbuf>>output;
 
@@ -91,7 +91,7 @@ int test1() {
 
         outbuf.seekg(0); //clean it
         outbuf << input;
-        bitpit::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
+        mimmo::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
         std::vector<std::array<long,4> >output;
         inbuf>>output;
 
@@ -124,7 +124,7 @@ int test1() {
 
         outbuf.seekg(0); //clean it
         outbuf << input;
-        bitpit::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
+        mimmo::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
         std::vector<mimmo::MimmoPiercedVector<std::string> *>output;
         inbuf>>output;
 
@@ -153,7 +153,7 @@ int test1() {
 
         outbuf.seekg(0); //clean it
         outbuf << input;
-        bitpit::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
+        mimmo::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
         std::vector<std::pair<int*,std::string>>output;
         inbuf>>output;
 
@@ -177,7 +177,7 @@ int test1() {
 
         outbuf.seekg(0); //clean it
         outbuf << input;
-        bitpit::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
+        mimmo::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
         std::vector<std::vector<double> >output;
         inbuf>>output;
 
@@ -204,7 +204,7 @@ int test1() {
 
         outbuf.seekg(0); //clean it
         outbuf << input;
-        bitpit::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
+        mimmo::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
         std::pair<double*, long* >output;
         inbuf>>output;
 
@@ -229,7 +229,7 @@ int test1() {
 
         outbuf.seekg(0); //clean it
         outbuf << input;
-        bitpit::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
+        mimmo::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
         std::pair<long, double* >output;
         inbuf>>output;
 
@@ -257,7 +257,7 @@ int test1() {
 
         outbuf.seekg(0); //clean it
         outbuf << input;
-        bitpit::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
+        mimmo::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
         std::unordered_map<double*, long*> output;
         inbuf>>output;
 
@@ -289,7 +289,7 @@ int test1() {
 
         outbuf.seekg(0); //clean it
         outbuf << input;
-        bitpit::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
+        mimmo::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
         std::unordered_map<double, long> output;
         inbuf>>output;
 
@@ -319,7 +319,7 @@ int test1() {
 
         outbuf.seekg(0); //clean it
         outbuf << input;
-        bitpit::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
+        mimmo::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
         std::unordered_map<std::string, std::pair<long, int>> output;
         inbuf>>output;
 
@@ -356,7 +356,7 @@ int test1() {
 
         outbuf.seekg(0); //clean it
         outbuf << input;
-        bitpit::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
+        mimmo::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
         mimmo::MimmoPiercedVector<std::string> output;
         inbuf>>output;
 
@@ -394,7 +394,7 @@ int test1() {
 
         outbuf.seekg(0); //clean it
         outbuf << input;
-        bitpit::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
+        mimmo::IBinaryStream inbuf(outbuf.data(), outbuf.getSize());
         mimmo::MimmoPiercedVector<std::array<double,3> > output;
         inbuf>>output;
 


### PR DESCRIPTION
The following pull request solves conflicts of mimmo binary stream operators custom declarations vs those already embedded in bitpit;
Tha basic idea is to derive custom mimmo IBinaryStream/OBinaryStream classes from those original of bitpit (without altering their interface and workflow) and to specialize stream operators <<, >> for these mimmo classes. 
This trick lets mimmo "overload" binary stream operators of bitpit.
Modifications are compliant with newer bitpit release candidates (master included) as well as the already released versions.

Modifications are successfully tested on both serial and parallel versions of mimmo.   