### PR TITLE
Core.mimmo object narrow band search.ra

### DIFF
--- a/examples/iocgns_example_00001.cpp
+++ b/examples/iocgns_example_00001.cpp
@@ -122,11 +122,14 @@ void example00001() {
     prop->setPlotInExecution(true);
     prop->setTolerance(1.0e-9);
     prop->setUpdateThreshold(1.0e-12);
-    prop->setDumping(true);
-    prop->setDumpingType(0);
-    prop->setDumpingInnerDistance(0.01);
-    prop->setDumpingOuterDistance(25.0);
-    prop->setDecayFactor(3.0);
+    prop->setDamping(true);
+    prop->setDampingType(0);
+    prop->setDampingInnerDistance(0.01);
+    prop->setDampingOuterDistance(80.0);
+    prop->setDampingDecayFactor(3.0);
+    prop->setNarrowBand(true);
+    prop->setNarrowBandWidth(80.0);
+    prop->setNarrowBandRelaxation(0.3);
     prop->forcePlanarSlip(true);
     prop->setSolverMultiStep(1);
 
@@ -174,6 +177,7 @@ void example00001() {
     mimmo::pin::addPin(cgnsDirichlet, prop, M_GEOM, M_GEOM2)  ;
     mimmo::pin::addPin(cgnsSlip, prop, M_GEOM, M_GEOM4)  ;
     mimmo::pin::addPin(boxSel, prop, M_GEOM, M_GEOM3)  ;
+    mimmo::pin::addPin(boxSel, prop, M_GEOM, M_GEOM7)  ;
 
     mimmo::pin::addPin(recon, prop, M_VECTORFIELD, M_GDISPLS)  ;
     mimmo::pin::addPin(prop, applier, M_GDISPLS, M_GDISPLS)  ;

--- a/examples/parallel_example_00003.cpp
+++ b/examples/parallel_example_00003.cpp
@@ -223,24 +223,36 @@ int test00003() {
 	// Now create a PropagateScalarField and solve the laplacian.
 	mimmo::PropagateVectorField * prop = new mimmo::PropagateVectorField();
 	prop->setGeometry(partition->getGeometry());
-	prop->setDirichletBoundarySurface(partition->getBoundaryGeometry());
-	prop->setDirichletConditions(&bc_surf_field);
-	prop->setDumping(false);
-	prop->setMethod(mimmo::PropagatorMethod::GRAPHLAPLACE);
-	prop->setSolverMultiStep(4);
+	prop->addDirichletBoundarySurface(partition->getBoundaryGeometry());
+	prop->addDirichletConditions(&bc_surf_field);
+	prop->setSolverMultiStep(10);
 	prop->setPlotInExecution(true);
 	prop->setApply(true);
 
-	t1 = Clock::now();
-	if (rank ==0)
-		std::cout << "Start Propagator vector field " << std::endl;
-	prop->exec();
-	t2 = Clock::now();
-	if (rank ==0){
-		std::cout << "Propagator vector field execution time: "
-				<< std::chrono::duration_cast<std::chrono::seconds>(t2 - t1).count()
-				<< " seconds" << std::endl;
-	}
+    prop->setDamping(true);
+    prop->setDampingType(1);
+    prop->setDampingDecayFactor(1.0);
+    prop->setDampingInnerDistance(0.05);
+    prop->setDampingOuterDistance(0.35);
+    prop->addDampingBoundarySurface(partition->getBoundaryGeometry());
+
+    // prop->setNarrowBand(true);
+    // prop->setNarrowBandWidth(0.6);
+    // prop->setNarrowBandRelaxation(0.7);
+    // prop->addNarrowBandBoundarySurface(partition->getBoundaryGeometry());
+
+
+    t1 = Clock::now();
+    if (rank == 0){
+        std::cout << "Start Propagator vector field " << std::endl;
+    }
+    prop->exec();
+    t2 = Clock::now();
+    if (rank ==0){
+        std::cout << "Propagator vector field execution time: "
+                  << std::chrono::duration_cast<std::chrono::seconds>(t2 - t1).count()
+                  << " seconds" << std::endl;
+    }
 
 	prop->getGeometry()->getPatch()->write("deformed");
 

--- a/src/common/portDefinitions.hpp
+++ b/src/common/portDefinitions.hpp
@@ -37,6 +37,7 @@
 #define M_GEOM4           "M_GEOM4"             /**< Port dedicated to communication of pointers to a MimmoObject object*/
 #define M_GEOM5           "M_GEOM5"             /**< Port dedicated to communication of pointers to a MimmoObject object*/
 #define M_GEOM6           "M_GEOM6"             /**< Port dedicated to communication of pointers to a MimmoObject object*/
+#define M_GEOM7           "M_GEOM7"             /**< Port dedicated to communication of pointers to a MimmoObject object*/
 #define M_GEOMOFOAM       "M_GEOMOFOAM"         /**< Port dedicated to communication of pointers to a MimmoObject object used as I/O between OFOAM blocks*/
 #define M_GEOMOFOAM2      "M_GEOMOFOAM2"        /**< Port dedicated to communication of pointers to a MimmoObject object used as I/O between OFOAM blocks*/
 #define M_VECGEOM         "M_VECGEOM"           /**< Port dedicated to communication of list of pointers to a MimmoObject object [ std::vector< MimmoObject* > ] */

--- a/src/core/MimmoObject.hpp
+++ b/src/core/MimmoObject.hpp
@@ -193,7 +193,8 @@ public:
     bitpit::PiercedVector<bitpit::Interface> &           getInterfaces();
     const bitpit::PiercedVector<bitpit::Interface> &     getInterfaces() const;
 
-    livector1D                                      getCellsIds();
+    livector1D                                      getCellsIds(bool internalsOnly = false);
+    livector1D                                      getVerticesIds(bool internalsOnly = false);
     bitpit::PatchKernel*                            getPatch();
     const bitpit::PatchKernel*                      getPatch() const;
     std::unordered_set<long> &                      getPIDTypeList();
@@ -312,6 +313,13 @@ public:
                                                                    const double & maxdist,
                                                                    livector1D * seedList = nullptr);
     bitpit::PiercedVector<double>   getCellsNarrowBandToExtSurfaceWDist(MimmoObject & surface,
+                                                                        const double & maxdist,
+                                                                        livector1D * seedList = nullptr);
+
+    livector1D                      getVerticesNarrowBandToExtSurface(MimmoObject & surface,
+                                                                   const double & maxdist,
+                                                                   livector1D * seedList = nullptr);
+    bitpit::PiercedVector<double>   getVerticesNarrowBandToExtSurfaceWDist(MimmoObject & surface,
                                                                         const double & maxdist,
                                                                         livector1D * seedList = nullptr);
 

--- a/src/core/MimmoPiercedVector.tpp
+++ b/src/core/MimmoPiercedVector.tpp
@@ -531,6 +531,7 @@ MimmoPiercedVector<mpv_t>::completeMissingData(const mpv_t & defValue){
 	if(!this->checkDataSizeCoherence()){
 
 		livector1D ids = this->getGeometryIds();
+        this->reserve(ids.size());
 		for(auto id: ids){
 			if(!this->exists(id)) this->insert(id, defValue);
 		}

--- a/test/propagators/test_propagators_00001.cpp
+++ b/test/propagators/test_propagators_00001.cpp
@@ -172,9 +172,9 @@ int test1() {
     mimmo::PropagateScalarField * prop = new mimmo::PropagateScalarField();
     prop->setName("test00001_PropagateScalarField");
     prop->setGeometry(mesh.get());
-    prop->setDirichletBoundarySurface(bdirMesh.get());
-    prop->setDirichletConditions(&bc_surf_field);
-    prop->setDumping(false);
+    prop->addDirichletBoundarySurface(bdirMesh.get());
+    prop->addDirichletConditions(&bc_surf_field);
+    prop->setDamping(false);
     prop->setPlotInExecution(true);
 
     prop->exec();
@@ -200,13 +200,13 @@ int test1() {
     mimmo::PropagateVectorField * prop3D = new mimmo::PropagateVectorField();
     prop3D->setName("test00001_PropagateVectorField");
     prop3D->setGeometry(mesh.get());
-    prop3D->setDirichletBoundarySurface(bdirMesh.get());
-    prop3D->setDirichletConditions(&bc_surf_3Dfield);
-    prop3D->setDumping(true);
-    prop3D->setDumpingType(1);
-    prop3D->setDecayFactor(1.0);
-    prop3D->setDumpingInnerDistance(0.5);
-    prop3D->setDumpingOuterDistance(3.5);
+    prop3D->addDirichletBoundarySurface(bdirMesh.get());
+    prop3D->addDirichletConditions(&bc_surf_3Dfield);
+    prop3D->setDamping(true);
+    prop3D->setDampingType(1);
+    prop3D->setDampingDecayFactor(1.0);
+    prop3D->setDampingInnerDistance(0.5);
+    prop3D->setDampingOuterDistance(3.5);
 
     prop3D->setPlotInExecution(true);
 

--- a/test/propagators/test_propagators_00002.cpp
+++ b/test/propagators/test_propagators_00002.cpp
@@ -281,11 +281,10 @@ int test1() {
     mimmo::PropagateScalarField * prop = new mimmo::PropagateScalarField();
     prop->setName("test00002_PropagateScalarField");
     prop->setGeometry(mesh.get());
-    prop->setDirichletBoundarySurface(boundary.get());
-    prop->setDirichletConditions(&bc_surf_field);
-    prop->setDumping(false);
+    prop->addDirichletBoundarySurface(boundary.get());
+    prop->addDirichletConditions(&bc_surf_field);
+    prop->setDamping(false);
     prop->setPlotInExecution(true);
-    prop->setMethod(mimmo::PropagatorMethod::GRAPHLAPLACE);
     prop->setSolverMultiStep(4);
     prop->exec();
 

--- a/test/propagators/test_propagators_00003.cpp
+++ b/test/propagators/test_propagators_00003.cpp
@@ -217,7 +217,7 @@ int test1() {
     //BEWARE IF THE ROTATION ARC IS similar to a linear segment, this deformation works,
     //for large rotation, where the arc path is very different from a different segment, this
     // could lead to not properly expected results.
-    double alpha = 9.0*BITPIT_PI/180.0;
+    double alpha = 25.0*BITPIT_PI/180.0;
     std::vector<long> d2 = bDIR->getVertexFromCellList(bDIR->extractPIDCells(2));
     for(long id : d2){
         darray3E coord = bDIR->getVertexCoords(id);
@@ -231,20 +231,18 @@ int test1() {
     mimmo::PropagateVectorField * prop3D = new mimmo::PropagateVectorField();
     prop3D->setName("test00003_PropagateVectorField");
     prop3D->setGeometry(mesh.get());
-    prop3D->setDirichletBoundarySurface(bDIR.get());
-    prop3D->setDirichletConditions(&bc_surf_3Dfield);
-    prop3D->setSlipBoundarySurface(bSLIP.get());
-    prop3D->setSlipReferenceSurface(bSLIP.get());
+    prop3D->addDirichletBoundarySurface(bDIR.get());
+    prop3D->addDirichletConditions(&bc_surf_3Dfield);
+    prop3D->addSlipBoundarySurface(bSLIP.get());
+    prop3D->addSlipReferenceSurface(bSLIP.get());
 
-    prop3D->setMethod(mimmo::PropagatorMethod::GRAPHLAPLACE);
+    prop3D->setDamping(true);
+    prop3D->setDampingType(0);
+    prop3D->setDampingDecayFactor(2.0);
+    prop3D->setDampingInnerDistance(0.5);
+    prop3D->setDampingOuterDistance(2.5);
 
-    prop3D->setDumping(true);
-    prop3D->setDumpingType(0);
-    prop3D->setDecayFactor(2.0);
-    prop3D->setDumpingInnerDistance(0.5);
-    prop3D->setDumpingOuterDistance(2.5);
-
-    prop3D->setSolverMultiStep(3);
+    prop3D->setSolverMultiStep(25);
 
     prop3D->setPlotInExecution(true);
 


### PR DESCRIPTION
General rework of Propagator classes to clean up algorithms and usage.
 - Modification on interfaces to deal with issue #111 
 - Temporary fix of point communications in communicatePointGhost data (perform twice the communication to fix data values on multiple-rank shared nodes).
 - Added NarrowBand control (alternative to Damping) to relax laplace propagation near boundaries.

Update MimmoObject interfaces, adding new methods (narrow band evaluation on points, get ids of cells and vertices directly to the object, etc...)
Fix setPartitioned method, which now internally builds adjacencies required by biptit::PatchKernel partition method.