### PR TITLE
core & iogeneric: add parallel support for SkdTree and export STL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,7 +98,7 @@ before_install:
   tee -a /etc/ssl/certs/ca-; fi
 install:
 - echo "Installing bitpit..." && git clone https://github.com/optimad/bitpit.git &&
-  cd bitpit && git checkout 9363feb4e6ee1582562f69b01be5c7bd083b0c40 && mkdir build && cd build && cmake -DCMAKE_C_COMPILER=${C_COMPILER}
+  cd bitpit && git checkout master && mkdir build && cd build && cmake -DCMAKE_C_COMPILER=${C_COMPILER}
   -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_Fortran_COMPILER=${Fortran_COMPILER}
   -DPETSC_DIR=/usr/lib/petscdir/3.6.2/x86_64-linux-gnu-real -DPETSC_ARCH= -DCMAKE_BUILD_TYPE=RelWithDebInfo
   -DENABLE_MPI=False -DVERBOSE_MAKE=False -DCMAKE_INSTALL_PREFIX=/opt/bitpit .. && make

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,20 @@ This library _tries_ to adhere to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Fixed
+- fixed get bounding box method of MimmoObject for parallel support
 - fixed copy during compilation of binary samples additional files
 - various bug fixes
 ### Added
+- added parallel SkdTreeUtils: use new parallel version of SkdTree of bitpit library
 - restored name in MimmoPiercedVector objects
 - new methods to write geometries with several and different kind of fields (scalar/vector, defined on points/cells) added to BaseManipulation class
 - added geometric tolerance to mimmo objects
 - added use of geometric tolerance and cleaning flag during reading with MimmoGeometry objects
-- Added RefineGeometry class to handle refinement of surface mesh: ternary and red-green engines provided for triangular based meshes
-- Added IOWaveFrontOBJ to handle input/output of surface mesh in Wavefront OBJ format. Enabled class ManipulateWFOBJData to manipulate data attached to the OBJ mesh (texture, normal fields, cell groups)
-- Added new feature to MRBF manipulator class, i.e. the possibility to handle RBF node set with variable support radii.
+- added RefineGeometry class to handle refinement of surface mesh: ternary and red-green engines provided for triangular based meshes
+- added IOWaveFrontOBJ to handle input/output of surface mesh in Wavefront OBJ format. Enabled class ManipulateWFOBJData to manipulate data attached to the OBJ mesh (texture, normal fields, cell groups)
+- added new feature to MRBF manipulator class, i.e. the possibility to handle RBF node set with variable support radii.
 ### Changed
+- update MimmoGeometry to export geometry object in a unique STL file during parallel processes
 - Geometry container MimmoObject through MimmoSharedPointer: use custom mimmo smart pointer to exchange geometries through ports or set/get method of blocks interfaces.
 - modified plotOptionalResults methods in some classes to use the new write function of base class
 - Point Cloud geometries now build the cell too. The cells are defined as bitpit::VERTEX type elements.

--- a/src/common/mimmoTypeDef.hpp
+++ b/src/common/mimmoTypeDef.hpp
@@ -91,7 +91,7 @@ typedef std::array<uarray3E,3>      umatrix33E; /**< mimmo custom typedef*/
 typedef std::array<dvector1D,3>     darr3Evec;  /**< mimmo custom typedef*/
 typedef std::array<darr3Evec,3>     dmat33Evec; /**< mimmo custom typedef*/
 
-typedef std::unordered_map<long int, long int>     liimap;     /**< mimmo custom typedef*/
+typedef std::unordered_map<long int, long int>     lilimap;     /**< mimmo custom typedef*/
 
 /*!
  * \}

--- a/src/core/BaseManipulation.cpp
+++ b/src/core/BaseManipulation.cpp
@@ -992,23 +992,7 @@ BaseManipulation::write(MimmoSharedPointer<MimmoObject> geometry)
 	bitpit::VTKUnstructuredGrid & VTK = geometry->getPatch()->getVTK();
 	VTK.setDirectory(m_outputPlot+"/");
 	VTK.setName(m_name+std::to_string(m_counter));
-
-//	if(geometry->getType() != 3){
-		geometry->getPatch()->write();
-//	}
-//	else{
-//		liimap mapDataInv;
-//		dvecarr3E points = geometry->getVerticesCoords(&mapDataInv);
-//		int size = points.size();
-//		ivector2D connectivity(size, ivector1D(1));
-//		for(int i=0; i<size; ++i)    connectivity[i][0]=i;
-////		VTK.setElementType(bitpit::VTKElementType::VERTEX);
-//		VTK.setGeomData( bitpit::VTKUnstructuredField::POINTS, points);
-//		VTK.setGeomData( bitpit::VTKUnstructuredField::CONNECTIVITY, connectivity);
-//		VTK.setDimensions(connectivity.size(), points.size());
-//		VTK.setCodex(bitpit::VTKFormat::APPENDED);
-//		VTK.write();
-//	}
+	geometry->getPatch()->write();
 }
 
 };

--- a/src/core/BaseManipulation.cpp
+++ b/src/core/BaseManipulation.cpp
@@ -969,6 +969,7 @@ BaseManipulation::_apply(MimmoPiercedVector<darray3E> & displacements)
     getGeometry()->getPatch()->updateBoundingBox(true);
 
 #if MIMMO_ENABLE_MPI
+    getGeometry()->cleanAllParallelSync();
     getGeometry()->updatePointGhostExchangeInfo();
 #endif
 

--- a/src/core/BaseManipulation.tpp
+++ b/src/core/BaseManipulation.tpp
@@ -153,8 +153,8 @@ void
 BaseManipulation::write(MimmoSharedPointer<MimmoObject> geometry, MimmoPiercedVector<mpv_t> & data)
 {
 
-	//Check data and geometry linked
-	if (data.size() == 0 || data.getGeometry() == nullptr){
+	//Check data with geometry linked
+	if (data.getGeometry() != geometry){
 		(*m_log) << " Warning: data to write not consistent with geometry in " << m_name << "; skip data" << std::endl;
 		write(geometry);
 		return;
@@ -225,8 +225,8 @@ template<typename mpv_t, typename... Args>
 void
 BaseManipulation::write(MimmoSharedPointer<MimmoObject> geometry, MimmoPiercedVector<mpv_t> & data, Args ... args)
 {
-	//Check data and geometry linked
-	if (data.size() == 0 || data.getGeometry() == nullptr){
+	//Check data with geometry linked
+	if (data.getGeometry() != geometry){
 		(*m_log) << " Warning: data to write not consistent with geometry in " << m_name << "; skip data" << std::endl;
 		write(geometry, args...);
 		return;
@@ -317,8 +317,8 @@ BaseManipulation::write(MimmoSharedPointer<MimmoObject> geometry, std::vector<Mi
 	for (MimmoPiercedVector<mpv_t> & data : vdata)
 	{
 
-		//Check data and geometry linked
-		if (data.size() == 0 || data.getGeometry() == nullptr){
+		//Check data with geometry linked
+		if (data.getGeometry() != geometry){
 			(*m_log) << " Warning: data to write not consistent with geometry in " << m_name << "; skip data" << std::endl;
 			continue;
 		}
@@ -402,8 +402,8 @@ BaseManipulation::write(MimmoSharedPointer<MimmoObject> geometry, std::vector<Mi
 	for (MimmoPiercedVector<mpv_t> & data : vdata)
 	{
 
-		//Check data and geometry linked
-		if (data.size() == 0 || data.getGeometry() == nullptr){
+		//Check data with geometry linked
+		if (data.getGeometry() != geometry){
 			(*m_log) << " Warning: data to write not consistent with geometry in " << m_name << "; skip data" << std::endl;
 			continue;
 		}
@@ -487,8 +487,8 @@ BaseManipulation::write(MimmoSharedPointer<MimmoObject> geometry, std::vector<Mi
     for (MimmoPiercedVector<mpv_t>* data : vdata)
     {
 
-        //Check data and geometry linked
-        if (data->size() == 0 || data->getGeometry() == nullptr){
+        //Check data with geometry linked
+        if (data->getGeometry() != geometry){
             (*m_log) << " Warning: data to write not consistent with geometry in " << m_name << "; skip data" << std::endl;
             continue;
         }
@@ -572,8 +572,8 @@ BaseManipulation::write(MimmoSharedPointer<MimmoObject> geometry, std::vector<Mi
     for (MimmoPiercedVector<mpv_t> * data : vdata)
     {
 
-        //Check data and geometry linked
-        if (data->size() == 0 || data->getGeometry() == nullptr){
+        //Check data with geometry linked
+        if (data->getGeometry() != geometry){
             (*m_log) << " Warning: data to write not consistent with geometry in " << m_name << "; skip data" << std::endl;
             continue;
         }

--- a/src/core/MimmoObject.cpp
+++ b/src/core/MimmoObject.cpp
@@ -2096,7 +2096,6 @@ void MimmoObject::resetPointGhostExchangeInfo()
 	m_pointGhostExchangeInfoSync = false;
 }
 
-
 /*!
     General checker for SkdTree status throughout all procs. If at least one partition
     has not-syncronized SkdTree set all the other procs to not syncronized and free the structure eventually.
@@ -2218,6 +2217,24 @@ bool MimmoObject::cleanParallelPointGhostExchangeInfoSync(){
 	}
 	//return true clean if the boolean was false, and viceversa.
 	return (!m_pointGhostExchangeInfoSync);
+}
+
+/*!
+    General checker for all InfoSync status throughout all procs. If at least one partition
+    has one not-syncronized InfoSync set all the other procs to not syncronized for this InfoSync
+    and free the structure eventually.
+    \return true if at least the structure was reset, false if nothing was done.
+ */
+bool MimmoObject::cleanAllParallelSync(){
+    bool reset = false;
+    reset |= cleanParallelSkdTreeSync();
+    reset |= cleanParallelKdTreeSync();
+    reset |= cleanParallelAdjacenciesSync();
+    reset |= cleanParallelInterfacesSync();
+    reset |= cleanParallelPointConnectivitySync();
+    reset |= cleanParallelInfoSync();
+    reset |= cleanParallelPointGhostExchangeInfoSync();
+    return reset;
 }
 
 /*!

--- a/src/core/MimmoObject.cpp
+++ b/src/core/MimmoObject.cpp
@@ -234,15 +234,11 @@ MimmoObject::MimmoObject(int type, dvecarr3E & vertex, livector2D * connectivity
 
 	m_log = &bitpit::log::cout(MIMMO_LOG_FILE);
 
-	//	if(connectivity == nullptr){
-	//		m_type = 3;
-	//	}else{
 	m_type = std::max(type,1);
 	if (m_type > 4){
 		(*m_log)<<"Error MimmoObject: unrecognized data structure type in class construction. Switch to DEFAULT 1-Surface"<<std::endl;
 		throw std::runtime_error ("MimmoObject : unrecognized mesh type in class construction");
 	}
-	//	}
 
 	switch(m_type){
 	case 1:
@@ -287,7 +283,6 @@ MimmoObject::MimmoObject(int type, dvecarr3E & vertex, livector2D * connectivity
 
 	m_log->setPriority(bitpit::log::Priority::DEBUG);
 
-	//	if(m_type != 3){
 	livector1D temp;
 	std::size_t sizeCell = connectivity->size();
 	m_patch->reserveCells(sizeCell);
@@ -303,10 +298,6 @@ MimmoObject::MimmoObject(int type, dvecarr3E & vertex, livector2D * connectivity
 	m_pidsType.insert(0);
 	m_pidsTypeWNames.insert(std::make_pair(0,""));
 
-	//	}else{
-	//		(*m_log)<<"Not supported connectivity found for MimmoObject"<<std::endl;
-	//		(*m_log)<<"Proceeding as Point Cloud geometry"<<std::endl;
-	//	}
 	m_log->setPriority(bitpit::log::Priority::NORMAL);
 
 #if MIMMO_ENABLE_MPI
@@ -346,7 +337,7 @@ MimmoObject::MimmoObject(int type, bitpit::PatchKernel* geometry){
 	if (geometry->getVertexCount() ==0){
 		(*m_log)<<"Error MimmoObject: no points detected in the linked mesh."<<std::endl;
 	}
-	if (geometry->getCellCount() ==0){ // && m_type != 3){
+	if (geometry->getCellCount() ==0){
 		(*m_log)<<"Error MimmoObject: no connectivity detected in the linked mesh."<<std::endl;
 	}
 
@@ -484,7 +475,7 @@ MimmoObject::MimmoObject(int type, std::unique_ptr<bitpit::PatchKernel> & geomet
 	if (geometry->getVertexCount() ==0){
 		(*m_log)<<"Error MimmoObject: no points detected in the linked mesh."<<std::endl;
 	}
-	if (geometry->getCellCount() ==0){ // && m_type != 3){
+	if (geometry->getCellCount() ==0){
 		(*m_log)<<"Error MimmoObject: no connectivity detected in the linked mesh."<<std::endl;
 	}
 
@@ -777,7 +768,6 @@ bool
 MimmoObject::isEmpty(){
 
 	bool check = getNVertices() == 0;
-	//	if(m_type != 3) check = check || (getNCells() == 0);
 	check = check || (getNCells() == 0);
 
 	return check;
@@ -868,10 +858,6 @@ MimmoObject::getNInternalVertices(){
 #endif
 		return getNVertices();
 #if MIMMO_ENABLE_MPI
-
-	//	if (!arePointGhostExchangeInfoSync())
-	//		updatePointGhostExchangeInfo();
-
 	return m_ninteriorvertices;
 #endif
 };
@@ -889,9 +875,6 @@ MimmoObject::getNGlobalVertices(){
 		return p->getVertexCount();
 	}
 
-	//	if (!arePointGhostExchangeInfoSync())
-	//		updatePointGhostExchangeInfo();
-
 	return m_nglobalvertices;
 };
 
@@ -907,6 +890,7 @@ MimmoObject::getNGlobalCells() {
 
 	if (!isInfoSync())
 		buildPatchInfo();
+
 	return getPatchInfo()->getCellGlobalCount();
 };
 
@@ -919,9 +903,6 @@ long
 MimmoObject::getPointGlobalCountOffset(){
 	if (!getPatch()->isPartitioned())
 		return 0;
-
-	//	if (!arePointGhostExchangeInfoSync())
-	//		updatePointGhostExchangeInfo();
 
 	return m_globaloffset;
 };
@@ -1355,7 +1336,6 @@ MimmoObject::getPIDTypeListWNames() const {
  */
 livector1D
 MimmoObject::getCompactPID() {
-	//	if(!m_skdTreeSupported || m_pidsType.empty())	return livector1D(0);
 	if(m_pidsType.empty())	return livector1D(0);
 	livector1D result(getNCells());
 	int counter=0;
@@ -1373,7 +1353,6 @@ MimmoObject::getCompactPID() {
  */
 std::unordered_map<long,long>
 MimmoObject::getPID() {
-	//	if(!m_skdTreeSupported || m_pidsType.empty())	return std::unordered_map<long,long>();
 	if(m_pidsType.empty())	return std::unordered_map<long,long>();
 	std::unordered_map<long,long> 	result;
 	for(auto const & cell : getCells()){
@@ -1457,16 +1436,9 @@ MimmoObject::isPointInterior(long id)
 {
 #if MIMMO_ENABLE_MPI
 
-	//TODO Initialize structure to true if not partitioned
 	//If not partitioned return true
 	if (!getPatch()->isPartitioned())
 		return true;
-
-	//	if (!arePointGhostExchangeInfoSync())
-	//		updatePointGhostExchangeInfo();
-
-	//	if (!m_isPointInterior.count(id))
-	//		return false;
 
 	return m_isPointInterior.at(id);
 
@@ -2490,7 +2462,6 @@ MimmoObject::addConnectedCell(const livector1D & conn, bitpit::ElementType type,
 	BITPIT_UNUSED(rank);
 #endif
 
-	//	if (conn.empty() || !m_skdTreeSupported) return false;
 	if (conn.empty()) return bitpit::Cell::NULL_ID;
 	if(idtag != bitpit::Cell::NULL_ID && getCells().exists(idtag)) return bitpit::Cell::NULL_ID;
 
@@ -2600,7 +2571,7 @@ MimmoObject::addCell(bitpit::Cell & cell, const long idtag, int rank){
  */
 void
 MimmoObject::setPID(livector1D pids){
-	if((int)pids.size() != getNCells()) return; // || !m_skdTreeSupported)	return;
+	if((int)pids.size() != getNCells()) return;
 
 	m_pidsType.clear();
 	m_pidsTypeWNames.clear();
@@ -2624,7 +2595,7 @@ MimmoObject::setPID(livector1D pids){
  */
 void
 MimmoObject::setPID(std::unordered_map<long, long> pidsMap){
-	if(getNCells() == 0) return; // || !m_skdTreeSupported)	return;
+	if(getNCells() == 0) return;
 
 	m_pidsType.clear();
 	m_pidsTypeWNames.clear();
@@ -2746,7 +2717,6 @@ bool
 MimmoObject::cleanGeometry(){
 	auto patch = getPatch();
 	patch->deleteCoincidentVertices();
-	//	if(m_skdTreeSupported)  patch->deleteOrphanVertices();
 
 	m_kdTreeSync = false;
 	m_infoSync = false;
@@ -4287,7 +4257,6 @@ MimmoObject::getVerticesNarrowBandToExtSurfaceWDist(MimmoObject & surface, const
 std::unordered_map<long,long> MimmoObject::getInverseConnectivity(){
 
 	std::unordered_map<long,long> invConn ;
-	//	if(getType() == 3) return invConn;
 
 	long cellId;
 	for(const auto &cell : getCells()){
@@ -4441,7 +4410,6 @@ MimmoObject::buildPointConnectivity()
 	if(getType() == 1 || getType() == 2 || getType() == 4){
 		//Surface/volume mesh & 3d curve point connectivity
 
-		//	std::set<long> visited;
 		//ONLY EDGE CONNECTIVITY
 		std::set<std::pair<long,long> > edges;
 		for (bitpit::Cell & cell : getCells()){
@@ -4477,26 +4445,6 @@ MimmoObject::buildPointConnectivity()
 				}
 			}
 		}
-
-		//
-		//	//ONE RING CELL CONNECTIVITY
-		//	for (bitpit::Cell & cell : getCells()){
-		//		long idcell = cell.getId();
-		//		int nv = cell.getVertexCount();
-		//		for (int iv=0; iv<nv; iv++){
-		//			long id = cell.getVertexId(iv);
-		//			if (!visited.count(id)){
-		//				livector1D list = getPatch()->findCellVertexOneRing(idcell, iv);
-		//				visited.insert(id);
-		//				for(const auto & cellIndex : list){
-		//			          bitpit::ConstProxyVector<long> ids = getPatch()->getCell(cellIndex).getVertexIds();
-		//			          m_pointConnectivity[id].insert(ids.begin(), ids.end());
-		//				}
-		//				m_pointConnectivity[id].erase(id);
-		//			}
-		//		}
-		//	}
-
 	}
 	else{
 		//No allowed type

--- a/src/core/MimmoObject.cpp
+++ b/src/core/MimmoObject.cpp
@@ -194,8 +194,7 @@ MimmoObject::MimmoObject(int type){
 	m_infoSync = true;
 	m_pointConnectivitySync = false;
 
-	m_tolerance = 1.0e-06;
-	m_patch->setTol(m_tolerance);
+	setTolerance(1.0e-06);
 }
 
 /*!
@@ -311,8 +310,7 @@ MimmoObject::MimmoObject(int type, dvecarr3E & vertex, livector2D * connectivity
 	m_infoSync = true;
 	m_pointConnectivitySync = false;
 
-	m_tolerance = 1.0e-06;
-    m_patch->setTol(m_tolerance);
+    setTolerance(1.0e-06);
 
 };
 
@@ -448,8 +446,7 @@ MimmoObject::MimmoObject(int type, bitpit::PatchKernel* geometry){
 	m_infoSync = true;
 	m_pointConnectivitySync = false;
 
-	m_tolerance = 1.0e-06;
-    m_patch->setTol(m_tolerance);
+    setTolerance(1.0e-06);
 
 }
 
@@ -587,8 +584,7 @@ MimmoObject::MimmoObject(int type, std::unique_ptr<bitpit::PatchKernel> & geomet
 	m_infoSync = true;
 	m_pointConnectivitySync = false;
 
-	m_tolerance = 1.0e-06;
-    m_patch->setTol(m_tolerance);
+    setTolerance(1.0e-06);
 
 }
 
@@ -2311,7 +2307,7 @@ void
 MimmoObject::setTolerance(double tol)
 {
 	m_tolerance = std::max(1.0e-15, tol);
-    m_patch->setTol(m_tolerance);
+    getPatch()->setTol(m_tolerance);
 }
 
 

--- a/src/core/MimmoObject.cpp
+++ b/src/core/MimmoObject.cpp
@@ -3875,7 +3875,7 @@ MimmoObject::getCellsNarrowBandToExtSurfaceWDist(MimmoObject & surface, const do
 
     //First step check seed list and precalculate distance. If dist >= maxdist
     //the seed candidate is out.
-    std::size_t npoints;
+    int npoints;
     darray3E point;
     dvecarr3E points;
     dvector1D distances;
@@ -3935,7 +3935,7 @@ MimmoObject::getCellsNarrowBandToExtSurfaceWDist(MimmoObject & surface, const do
     }
 
     // Fill seeds (directly in result) if distance < maxdistance
-    for (std::size_t ipoint = 0; ipoint < npoints; ipoint++){
+    for (int ipoint = 0; ipoint < npoints; ipoint++){
         distance = distances[ipoint];
         id = candidates->at(ipoint);
         if(distance < maxdist){
@@ -4002,7 +4002,7 @@ MimmoObject::getCellsNarrowBandToExtSurfaceWDist(MimmoObject & surface, const do
         }
 
         // Fill points inside narrow band in result and their neighbours in stack
-        for (std::size_t ipoint = 0; ipoint < npoints; ipoint++){
+        for (int ipoint = 0; ipoint < npoints; ipoint++){
             distance = distances[ipoint];
             id = stackNeighs[ipoint];
             if(distance < maxdist){
@@ -4079,7 +4079,7 @@ MimmoObject::getVerticesNarrowBandToExtSurfaceWDist(MimmoObject & surface, const
 
     //First step check seed list and precalculate distance. If dist >= maxdist
     //the seed candidate is out.
-    std::size_t npoints;
+    int npoints;
     darray3E point;
     dvecarr3E points;
     dvector1D distances;
@@ -4145,7 +4145,7 @@ MimmoObject::getVerticesNarrowBandToExtSurfaceWDist(MimmoObject & surface, const
     }
 
     // Fill seed points (directly in result) if distance < maxdistance
-    for (std::size_t ipoint = 0; ipoint < npoints; ipoint++){
+    for (int ipoint = 0; ipoint < npoints; ipoint++){
         distance = distances[ipoint];
         id = candidates->at(ipoint);
         if(distance < maxdist){
@@ -4212,7 +4212,7 @@ MimmoObject::getVerticesNarrowBandToExtSurfaceWDist(MimmoObject & surface, const
         }
 
         // Fill points inside narrow band in result and their neighbours in stack
-        for (std::size_t ipoint = 0; ipoint < npoints; ipoint++){
+        for (int ipoint = 0; ipoint < npoints; ipoint++){
             distance = distances[ipoint];
             id = stackNeighs[ipoint];
             if(distance < maxdist){

--- a/src/core/MimmoObject.cpp
+++ b/src/core/MimmoObject.cpp
@@ -3910,7 +3910,9 @@ MimmoObject::getCellsNarrowBandToExtSurfaceWDist(MimmoObject & surface, const do
 			auto itsurfend = loop.end();
 			while(itsurf != itsurfend ){
 				//continue to search for a seed cell candidate, visiting all point of the target surface.
-				idseed = mimmo::skdTreeUtils::closestCellToPoint(surface.evalCellCentroid(*itsurf), *(this->getSkdTree()));
+				//idseed = mimmo::skdTreeUtils::closestCellToPoint(surface.evalCellCentroid(*itsurf), *(this->getSkdTree()));
+			    double dummydistance;
+			    static_cast<bitpit::SurfaceSkdTree*>(this->getSkdTree())->findPointClosestCell(surface.evalCellCentroid(*itsurf), &idseed, &dummydistance);
 				if(idseed < 0) {
 					++itsurf;
 					continue;
@@ -4054,7 +4056,9 @@ MimmoObject::getVerticesNarrowBandToExtSurfaceWDist(MimmoObject & surface, const
 			auto itsurfend = loop.end();
 			while(itsurf != itsurfend ){
 				//continue to search for a seed cell candidate, visiting all point of the target surface.
-				idcellseed = mimmo::skdTreeUtils::closestCellToPoint(surface.evalCellCentroid(*itsurf), *(this->getSkdTree()));
+			    //idcellseed = mimmo::skdTreeUtils::closestCellToPoint(surface.evalCellCentroid(*itsurf), *(this->getSkdTree()));
+                double dummydistance;
+                static_cast<bitpit::SurfaceSkdTree*>(this->getSkdTree())->findPointClosestCell(surface.evalCellCentroid(*itsurf), &idcellseed, &dummydistance);
 				if(idcellseed < 0) {
 					++itsurf;
 					continue;

--- a/src/core/MimmoObject.cpp
+++ b/src/core/MimmoObject.cpp
@@ -1148,29 +1148,28 @@ MimmoObject::getCellsIds(bool internalsOnly){
 /*!
  * Return a compact vector with the Ids of local vertices given by
  * bitpit::PatchKernel unique-labeled indexing.
-   \param[in] internalsOnly FOR MPI ONLY: if true method accounts for internal vertices only,
-   if false it includes also ghosts. Serial comp ignore this parameter.
+   \param[in] internalsOnly if true method accounts for internal vertices only,
+   if false it includes also ghosts.
  * \return ids of vertices
  */
 livector1D
 MimmoObject::getVerticesIds(bool internalsOnly){
-    std::vector<long> ids;
 
-#if MIMMO_ENABLE_MPI
-    //MPI version
+    livector1D ids;
+
     if(internalsOnly){
         ids.reserve(getNInternalVertices());
-        for(bitpit::PatchKernel::VertexIterator it = getPatch()->vertexBegin(); it!= getPatch()->vertexEnd(); ++it){
-            if(isPointInterior(it.getId())) ids.push_back(it.getId());
-        }
-    }else{
-        ids = getPatch()->getVertices().getIds();
     }
-#else
-    //SERIAL version
-    BITPIT_UNUSED(internalsOnly);
-    ids = getPatch()->getVertices().getIds();
-#endif
+    else{
+        ids.reserve(getNVertices());
+    }
+
+    for(const bitpit::Vertex & vertex : getVertices()){
+        long vertexId = vertex.getId();
+        if(!internalsOnly || isPointInterior(vertexId)){
+            ids.push_back(vertexId);
+        }
+    }
 
     return ids;
 };

--- a/src/core/MimmoObject.cpp
+++ b/src/core/MimmoObject.cpp
@@ -936,7 +936,7 @@ MimmoObject::getPointGlobalCountOffset(){
                for aligning external vertex data to bitpit::Patch ordering.
  */
 dvecarr3E
-MimmoObject::getVerticesCoords(liimap* mapDataInv){
+MimmoObject::getVerticesCoords(lilimap* mapDataInv){
 	dvecarr3E result(getNVertices());
 	int  i = 0;
 
@@ -1004,7 +1004,7 @@ MimmoObject::getVertices() const {
  * \param[in] mapDataInv inverse of Map of vertex ids actually set, for aligning external vertex data to bitpit::Patch ordering
  */
 livector2D
-MimmoObject::getCompactConnectivity(liimap & mapDataInv){
+MimmoObject::getCompactConnectivity(lilimap & mapDataInv){
 
 	livector2D connecti(getNCells());
 	int np, counter =0;
@@ -1223,10 +1223,10 @@ MimmoObject::getPatch() const{
  * \param[in] withghosts If true the structure is filled with ghosts (meaningful only in parallel versions)
  * \return local/unique-id map
  */
-liimap
+lilimap
 MimmoObject::getMapData(bool withghosts){
-	liimap mapData;
-	liimap mapDataInv = getMapDataInv(withghosts);
+	lilimap mapData;
+	lilimap mapDataInv = getMapDataInv(withghosts);
 	for (auto const & vertex : getVertices()){
 		long id = vertex.getId();
 		if (mapDataInv.count(id))
@@ -1241,9 +1241,9 @@ MimmoObject::getMapData(bool withghosts){
  * \param[in] withghosts If true the structure is filled with ghosts (meaningful only in parallel versions)
  * \return unique-id/local map
  */
-liimap
+lilimap
 MimmoObject::getMapDataInv(bool withghosts){
-	liimap mapDataInv;
+	lilimap mapDataInv;
 #if MIMMO_ENABLE_MPI
 	if (getPatch()->isPartitioned()){
 		for (auto val : m_pointConsecutiveId){
@@ -1272,9 +1272,9 @@ MimmoObject::getMapDataInv(bool withghosts){
  * \param[in] withghosts If true the structure is filled with ghosts (meaningful only in parallel versions)
  * \return global consecutive / local unique id map
  */
-liimap
+lilimap
 MimmoObject::getMapCell(bool withghosts){
-	liimap mapCell;
+	lilimap mapCell;
 	if (!isInfoSync()) buildPatchInfo();
 	for (auto const & cell : getCells()){
 		long id = cell.getId();
@@ -1294,10 +1294,10 @@ MimmoObject::getMapCell(bool withghosts){
  * \param[in] withghosts If true the structure is filled with ghosts (meaningful only in parallel versions)
  * \return local unique id / global consecutive map
  */
-liimap
+lilimap
 MimmoObject::getMapCellInv(bool withghosts){
 	if (!isInfoSync()) buildPatchInfo();
-	liimap mapCellInv = getPatchInfo()->getCellConsecutiveMap();
+	lilimap mapCellInv = getPatchInfo()->getCellConsecutiveMap();
 	if (!withghosts){
 		std::vector<long> todelete;
 		for (auto & val : mapCellInv){

--- a/src/core/MimmoObject.cpp
+++ b/src/core/MimmoObject.cpp
@@ -3209,10 +3209,10 @@ bool MimmoObject::checkCellConnCoherence(const bitpit::ElementType & type, const
  * Evaluate axis aligned bounding box of the current MimmoObject.
  * \param[out] pmin lowest bounding box point
  * \param[out] pmax highest bounding box point
+ * \param[in] global true to ask for global bounding box over the processes
  */
-void MimmoObject::getBoundingBox(std::array<double,3> & pmin, std::array<double,3> & pmax){
-	getPatch()->getBoundingBox(pmin,pmax);
-	return;
+void MimmoObject::getBoundingBox(std::array<double,3> & pmin, std::array<double,3> & pmax, bool global){
+	getPatch()->getBoundingBox(global, pmin, pmax);
 }
 
 

--- a/src/core/MimmoObject.hpp
+++ b/src/core/MimmoObject.hpp
@@ -236,6 +236,7 @@ public:
     bool cleanParallelPointGhostExchangeInfoSync();
     bool cleanAllParallelSync();
     void setPartitioned();
+    bool isPartitioned();
     void deleteOrphanGhostCells();
 #endif
 

--- a/src/core/MimmoObject.hpp
+++ b/src/core/MimmoObject.hpp
@@ -182,12 +182,12 @@ public:
     long                                            getNGlobalCells();
     long                                            getPointGlobalCountOffset();
 #endif
-    dvecarr3E                                       getVerticesCoords(liimap* mapDataInv = nullptr);
+    dvecarr3E                                       getVerticesCoords(lilimap* mapDataInv = nullptr);
     const darray3E &                                getVertexCoords(long i) const;
     bitpit::PiercedVector<bitpit::Vertex> &         getVertices();
     const bitpit::PiercedVector<bitpit::Vertex> &   getVertices() const ;
 
-    livector2D                                      getCompactConnectivity(liimap & mapDataInv);
+    livector2D                                      getCompactConnectivity(lilimap & mapDataInv);
     livector2D                                      getConnectivity();
     livector1D                                      getCellConnectivity(long id) const ;
     bitpit::PiercedVector<bitpit::Cell> &           getCells();
@@ -277,10 +277,10 @@ public:
 
     std::map<long, livector1D> extractPIDSubdivision();
 
-    liimap      getMapData(bool withghosts=false);
-    liimap      getMapDataInv(bool withghosts=true);
-    liimap	    getMapCell(bool withghosts=true);
-    liimap      getMapCellInv(bool withghosts=true);
+    lilimap      getMapData(bool withghosts=false);
+    lilimap      getMapDataInv(bool withghosts=true);
+    lilimap	    getMapCell(bool withghosts=true);
+    lilimap      getMapCellInv(bool withghosts=true);
 
     void        getBoundingBox(std::array<double,3> & pmin, std::array<double,3> & pmax);
     void        buildSkdTree(std::size_t value = 1);

--- a/src/core/MimmoObject.hpp
+++ b/src/core/MimmoObject.hpp
@@ -234,6 +234,7 @@ public:
     bool cleanParallelPointConnectivitySync();
     bool cleanParallelInfoSync();
     bool cleanParallelPointGhostExchangeInfoSync();
+    bool cleanAllParallelSync();
     void setPartitioned();
     void deleteOrphanGhostCells();
 #endif

--- a/src/core/MimmoObject.hpp
+++ b/src/core/MimmoObject.hpp
@@ -283,7 +283,7 @@ public:
     lilimap	    getMapCell(bool withghosts=true);
     lilimap      getMapCellInv(bool withghosts=true);
 
-    void        getBoundingBox(std::array<double,3> & pmin, std::array<double,3> & pmax);
+    void        getBoundingBox(std::array<double,3> & pmin, std::array<double,3> & pmax, bool global = true);
     void        buildSkdTree(std::size_t value = 1);
     void        buildKdTree();
     void		buildPatchInfo();

--- a/src/core/SkdTreeUtils.cpp
+++ b/src/core/SkdTreeUtils.cpp
@@ -27,6 +27,7 @@
 # include <bitpit_surfunstructured.hpp>
 # include <surface_skd_tree.hpp>
 # include <CG.hpp>
+# include <queue>
 
 namespace mimmo{
 
@@ -37,30 +38,29 @@ namespace skdTreeUtils{
  * object. The geometry has to be a surface mesh, in particular an object of type
  * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
  * It searches the element with minimum distance in a box of length 2*r, if none
- * is found return a default value of distance equal to 1.0e+18;
- * \param[in] P_ Pointer to coordinates of input point.
- * \param[in] bvtree_ Pointer to Boundary Volume Hierarchy tree that stores the geometry.
+ * is found return a default value of distance equal to std::numeric_limits<double>::max();
+ * \param[in] point Pointer to coordinates of input point.
+ * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
  * \param[out] id Label of the element found as minimum distance element in the bv-tree.
  * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
  * every element encountered inside the box/sphere).
  * \return Unsigned distance of the input point from the patch in the bv-tree.
  */
-double distance(std::array<double,3> *P_, bitpit::PatchSkdTree *bvtree_, long &id, double &r)
+double distance(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long &id, double r)
 {
 
-    double h = 1.E+18;
-    if(!bvtree_ ){
+    double h = std::numeric_limits<double>::max();
+    if(!tree ){
         throw std::runtime_error("Invalid use of skdTreeUtils::distance method: a void tree is detected.");
     }
-    if(!dynamic_cast<const bitpit::SurfUnstructured*>(&(bvtree_->getPatch()))){
+    if(!dynamic_cast<const bitpit::SurfUnstructured*>(&(tree->getPatch()))){
         throw std::runtime_error("Invalid use of skdTreeUtils::distance method: a not surface patch tree is detected.");
     }
 
-    static_cast<bitpit::SurfaceSkdTree*>(bvtree_)->findPointClosestCell(*P_, r, &id, &h);
+    static_cast<const bitpit::SurfaceSkdTree*>(tree)->findPointClosestCell(*point, r, &id, &h);
     return h;
 
 }
-
 
 /*!
  * It computes the signed distance of a point to a geometry linked in a SkdTree
@@ -70,88 +70,119 @@ double distance(std::array<double,3> *P_, bitpit::PatchSkdTree *bvtree_, long &i
  * computed. A positive distance means that the point is located, in respect to the
  * surface mesh, on the same side of the outer normal vector.
  * It searches the element with minimum distance in a box of length 2*r, if none
- * is found return a default value of distance equal to 1.0e+18;
- * \param[in] P_ Pointer to coordinates of input point.
- * \param[in] bvtree_ Pointer to Boundary Volume Hierarchy tree that stores the geometry.
+ * is found return a default value of distance equal to std::numeric_limits<double>::max();
+ * \param[in] point Pointer to coordinates of input point.
+ * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
  * \param[out] id Label of the element found as minimum distance element in the bv-tree.
- * \param[out] n Pseudo-normal of the element (i.e. unit vector with direction (P-xP),
+ * \param[out] normal Pseudo-normal of the element (i.e. unit vector with direction (P-xP),
  * where P is the input point and xP the nearest point on the element (simplex) to
  * the projection of P on the plane of the simplex.
  * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
  * every element encountered inside the box/sphere).
  * \return Signed distance of the input point from the patch in the bv-tree.
  */
-double signedDistance(std::array<double,3> *P_, bitpit::PatchSkdTree *bvtree_, long &id, std::array<double,3> &n, double &r)
+double signedDistance(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long &id, std::array<double,3> &normal, double r)
 {
 
-    double h = 1.E+18;
+    double h = std::numeric_limits<double>::max();
 
-    if(!bvtree_ ){
+    if(!tree ){
     	throw std::runtime_error("Invalid use of skdTreeUtils::signedDistance method: a void tree is detected.");
     }
-    const bitpit::SurfUnstructured *spatch = dynamic_cast<const bitpit::SurfUnstructured*>(&(bvtree_->getPatch()));
+    const bitpit::SurfUnstructured *spatch = dynamic_cast<const bitpit::SurfUnstructured*>(&(tree->getPatch()));
     if(!spatch){
     	throw std::runtime_error("Invalid use of skdTreeUtils::signedDistance method: a not surface patch tree is detected.");
     }
 
-    static_cast<bitpit::SurfaceSkdTree*>(bvtree_)->findPointClosestCell(*P_, r, &id, &h);
+    static_cast<const bitpit::SurfaceSkdTree*>(tree)->findPointClosestCell(*point, r, &id, &h);
 
-    //signed distance only for 2D element patches(quads, pixels, triangles or segments)
-    if (id != bitpit::Cell::NULL_ID){
-    	const bitpit::Cell & cell = spatch->getCell(id);
-    	bitpit::ConstProxyVector<long> vertIds = cell.getVertexIds();
-    	dvecarr3E VS(vertIds.size());
-    	int count = 0;
-    	for (const auto & iV: vertIds){
-    		VS[count] = spatch->getVertexCoords(iV);
-    		++count;
-    	}
+    normal = computePseudoNormal(*point, spatch, id);
 
-    	darray3E xP = {{0.0,0.0,0.0}};
-    	darray3E normal= {{0.0,0.0,0.0}};
-
-    	if ( vertIds.size() == 3 ){ //TRIANGLE
-    		darray3E lambda;
-    		h = bitpit::CGElem::distancePointTriangle((*P_), VS[0], VS[1], VS[2],lambda);
-    		int count = 0;
-    		for(const auto &val: lambda){
-    			normal += val * spatch->evalVertexNormal(id,count) ;
-    			xP += val * VS[count];
-    			++count;
-    		}
-    	}else if ( vertIds.size() == 2 ){ //LINE/SEGMENT
-    		darray2E lambda;
-    		h = bitpit::CGElem::distancePointSegment((*P_), VS[0], VS[1], lambda);
-    		int count = 0;
-    		for(const auto &val: lambda){
-    			normal += val * spatch->evalVertexNormal(id,count) ;
-    			xP += val * VS[count];
-    			++count;
-    		}
-    	}else{ //GENERAL POLYGON
-    		std::vector<double> lambda;
-    		h = bitpit::CGElem::distancePointPolygon((*P_), VS,lambda);
-    		int count = 0;
-    		for(const auto &val: lambda){
-    			normal += val * spatch->evalVertexNormal(id,count) ;
-    			xP += val * VS[count];
-    			++count;
-    		}
-    	}
-
-    	double s =  sign( dotProduct(normal, (*P_) - xP) );
-    	if(s == 0.0)    s =1.0;
-    	h = s * h;
-    	//pseudo-normal (direction P and xP closest point on triangle)
-    	n = s * ((*P_) - xP);
-    	double normX = norm2(n);
-    	if(normX < 1.E-15){
-    		n = normal/norm2(normal);
-    	}else{
-    		n /= norm2(n);
-    	}
-    }//end if not id null
     return h;
+
+}
+
+/*!
+ * It computes the unsigned distance of a set of points to a geometry linked in a SkdTree
+ * object. The geometry has to be a surface mesh, in particular an object of type
+ * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
+ * It searches the element with minimum distance in a box of length 2*r, if none
+ * is found return a default value of distance equal to std::numeric_limits<double>::max();
+ * \param[in] nP Number of input points.
+ * \param[in] points Pointer to coordinates of input points.
+ * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
+ * \param[out] distances Unsigned distance of the input points from the patch in the bv-tree.
+ * \param[out] ids Label of the elements found as minimum distance elements in the bv-tree.
+ * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
+ * every element encountered inside the box/sphere).
+ */
+void distance(size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, double *distances, double r)
+{
+
+    // Initialize distances
+    for (std::size_t ip = 0; ip < nP; ip++){
+        distances[ip] = std::numeric_limits<double>::max();
+    }
+
+    if(!tree ){
+        throw std::runtime_error("Invalid use of skdTreeUtils::distance method: a void tree is detected.");
+    }
+    if(!dynamic_cast<const bitpit::SurfUnstructured*>(&(tree->getPatch()))){
+        throw std::runtime_error("Invalid use of skdTreeUtils::distance method: a not surface patch tree is detected.");
+    }
+
+    for (std::size_t ip = 0; ip < nP; ip++){
+        const std::array<double,3> *point = &points[ip];
+        long *id = &ids[ip];
+        double *distance = &distances[ip];
+        static_cast<const bitpit::SurfaceSkdTree*>(tree)->findPointClosestCell(*point, r, id, distance);
+    }
+
+}
+
+/*!
+ * It computes the signed distance of a set of points to a geometry linked in a SkdTree
+ * object. The geometry must be a surface mesh, in particular an object of type
+ * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
+ * The sign of the distance is provided by the normal to the geometry locally
+ * computed. A positive distance means that the point is located, in respect to the
+ * surface mesh, on the same side of the outer normal vector.
+ * It searches the element with minimum distance in a box of length 2*r, if none
+ * is found return a default value of distance equal to std::numeric_limits<double>::max();
+ * \param[in] nP Number of input points.
+ * \param[in] points Pointer to coordinates of input points.
+ * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
+ * \param[out] distances Signed distance of the input points from the patch in the bv-tree.
+ * \param[out] ids Label of the elements found as minimum distance elements in the bv-tree.
+ * \param[out] normals Pseudo-normal of the elements (i.e. unit vector with direction (P-xP),
+ * where P is the input point and xP the nearest point on the element (simplex) to
+ * the projection of P on the plane of the simplex.
+ * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
+ * every element encountered inside the box/sphere).
+ */
+double signedDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, std::array<double,3> *normals, double *distances, double r)
+{
+
+    // Initialize distances
+    for (std::size_t ip = 0; ip < nP; ip++){
+        distances[ip] = std::numeric_limits<double>::max();
+    }
+
+    if(!tree ){
+        throw std::runtime_error("Invalid use of skdTreeUtils::signedDistance method: a void tree is detected.");
+    }
+    const bitpit::SurfUnstructured *spatch = dynamic_cast<const bitpit::SurfUnstructured*>(&(tree->getPatch()));
+    if(!spatch){
+        throw std::runtime_error("Invalid use of skdTreeUtils::signedDistance method: a not surface patch tree is detected.");
+    }
+
+    for (std::size_t ip = 0; ip < nP; ip++){
+        const std::array<double,3> *point = &points[ip];
+        long *id = &ids[ip];
+        double *distance = &distances[ip];
+        static_cast<const bitpit::SurfaceSkdTree*>(tree)->findPointClosestCell(*point, r, id, distance);
+        normals[ip] = computePseudoNormal(*point, spatch, *id);
+    }
 
 }
 
@@ -211,7 +242,7 @@ std::vector<long> selectByPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSk
 void extractTarget(bitpit::PatchSkdTree *target, const std::vector<const bitpit::SkdNode*> & leafSelection, std::vector<long> &extracted, double tol){
 
     if(leafSelection.empty())   return;
-    std::size_t rootId  =0;
+    std::size_t rootId = 0;
 
     std::vector<std::size_t> candidates;
     std::vector<std::pair< std::size_t, std::vector<const bitpit::SkdNode*> > > nodeStack;
@@ -278,29 +309,60 @@ void extractTarget(bitpit::PatchSkdTree *target, const std::vector<const bitpit:
  * recursively in a sphere of radius r, by increasing the size r at each step
  * until at least one element is found.
  * \param[in] P_ Pointer to coordinates of input point.
- * \param[in] bvtree_ Pointer to Boundary Volume Hierarchy tree that stores the geometry.
+ * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
  * \param[in] r Initial length of the sphere radius used to search. (The algorithm checks
  * every element encountered inside the sphere).
  * \return Coordinates of the projected point.
  */
-darray3E projectPoint( std::array<double,3> *P_, bitpit::PatchSkdTree *bvtree_, double r )
+darray3E projectPoint(const std::array<double,3> *point, const bitpit::PatchSkdTree *skdtree, double r )
+{
+    darray3E projected_point;
+    long id;
+    projectPoint(1, point, skdtree, &projected_point, &id, r);
+    return projected_point;
+}
+
+/*!
+ * It computes the projection of a set of points on a geometry linked in a skdtree
+ * object. The geometry must be a surface mesh, in particular an object of type
+ * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
+ * It searches the elements of the geometry with minimum distance
+ * recursively in a sphere of radius r, by increasing the size r at each step
+ * until at least one element is found.
+ * \param[in] nP Number of input points.
+ * \param[in] points Pointer to coordinates of input points.
+ * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
+ * \param[out] ids Labels of the elements found as minimum distance element into the points are projected.
+ * \param[in] r Initial length of the sphere radius used to search. (The algorithm checks
+ * every element encountered inside the sphere).
+ * \param[out] Coordinates of the projected points.
+ */
+void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double r )
 {
 
-    long         id;
-    darray3E     normal;
+    // Initialize ids and ranks
+    for (std::size_t ip = 0; ip < nP; ip++){
+        ids[ip] = bitpit::Cell::NULL_ID;
+    }
+    std::vector<darray3E>    normals(nP);
 
-    r = std::max(r, bvtree_->getPatch().getTol());
+    r = std::max(r, tree->getPatch().getTol());
 
-    double         dist = 1.0e+18;
-    while (std::abs(dist) >= 1.0e+18){
+    std::vector<double> dist(nP, std::numeric_limits<double>::max());
+    double max_dist = std::numeric_limits<double>::max();
+    while (max_dist == std::numeric_limits<double>::max()){
         //use method sphere by default
-        dist = signedDistance(P_, bvtree_, id, normal, r);
+        for (std::size_t ip = 0; ip < nP; ip++){
+            dist[ip] = signedDistance(&points[ip], tree, ids[ip], normals[ip], r);
+        }
         r *= 1.5;
+        max_dist = std::abs(*std::max_element(dist.begin(), dist.end()));
+        max_dist = std::max(max_dist, std::abs(*std::min_element(dist.begin(), dist.end())));
     }
 
-    darray3E     projP = (*P_) - dist*normal;
-
-    return (projP);
+    for (std::size_t ip = 0; ip < nP; ip++){
+        projected_points[ip] = points[ip] - dist[ip] * normals[ip];
+    }
 }
 
 /*!
@@ -311,127 +373,52 @@ darray3E projectPoint( std::array<double,3> *P_, bitpit::PatchSkdTree *bvtree_, 
  * \param[in] tree reference to SkdTree relative to the target surface geometry.
  * \return id of the geometry cell the point is into. Return bitpit::Cell::NULL_ID if no cell is found.
  */
-long locatePointOnPatch(const std::array<double, 3> &point, bitpit::PatchSkdTree &tree)
+long locatePointOnPatch(const std::array<double, 3> &point, const bitpit::PatchSkdTree *tree)
 {
-    if(!dynamic_cast<const bitpit::SurfUnstructured*>(&(tree.getPatch()))){
+    if(!dynamic_cast<const bitpit::SurfUnstructured*>(&(tree->getPatch()))){
         throw std::runtime_error("Invalid use of skdTreeUtils::locatePointOnPatch method: a non surface patch or void patch was detected.");
     }
-    // Initialize the cell id
+
+    // Initialize the cell id and distance
     long id = bitpit::Cell::NULL_ID;
+    double distance = std::numeric_limits<double>::max();
 
-    // Initialize the distance with an estimate
-    //
-    // The real distance will be lesser than or equal to the estimate.
-    std::size_t rootId = 0;
-    const bitpit::SkdNode &root = tree.getNode(rootId);
-    double distance = root.evalPointMaxDistance(point);
+    // Find the closest cell to the input point
+    long cellId = bitpit::Cell::NULL_ID;
+    static_cast<const bitpit::SurfaceSkdTree*>(tree)->findPointClosestCell(point, &cellId, &distance);
 
-    // Get a list of candidates nodes
-    //
-    std::vector<std::size_t>    m_candidateIds;
+    // Check if the point belongs to the closest cell
+    bool checkBelong = false;
 
-    std::vector<std::size_t> nodeStack;
-    nodeStack.push_back(rootId);
-    while (!nodeStack.empty()) {
-        std::size_t nodeId = nodeStack.back();
-        const bitpit::SkdNode &node = tree.getNode(nodeId);
-        nodeStack.pop_back();
-
-        // Do not consider nodes with a minimum distance greater than
-        // the distance estimate
-        double nodeMinDistance = node.evalPointMinDistance(point);
-        if (nodeMinDistance > distance) {
-            continue;
-        }
-
-        // Update the distance estimate
-        //
-        // The real distance will be lesser than or equal to the
-        // estimate.
-        double nodeMaxDistance = node.evalPointMaxDistance(point);
-        distance = std::min(nodeMaxDistance, distance);
-
-        // If the node is a leaf add it to the candidates, otherwise
-        // add its children to the stack.
-        bool isLeaf = true;
-        for (int i = bitpit::SkdNode::CHILD_BEGIN; i != bitpit::SkdNode::CHILD_END; ++i) {
-            bitpit::SkdNode::ChildLocation childLocation = static_cast<bitpit::SkdNode::ChildLocation>(i);
-            std::size_t childId = node.getChildId(childLocation);
-            if (childId != bitpit::SkdNode::NULL_ID) {
-                isLeaf = false;
-                nodeStack.push_back(childId);
-            }
-        }
-
-        if (isLeaf) {
-            m_candidateIds.push_back(nodeId);
-        }
+    bitpit::ElementType eltype = tree->getPatch().getCell(cellId).getType();
+    auto vList = tree->getPatch().getCell(cellId).getVertexIds();
+    dvecarr3E vertCoords(vList.size());
+    int counterList = 0;
+    for(const auto & idV : vList){
+        vertCoords[counterList] = tree->getPatch().getVertexCoords(idV);
+        ++counterList;
     }
 
-
-    // Process the candidates to eliminate some of them
-    std::vector<long> toerase;
-    for (std::size_t k = 0; k < m_candidateIds.size(); ++k) {
-
-        // Evaluate the min distance between all cells in the candidate node
-        std::size_t nodeId = m_candidateIds[k];
-        const bitpit::SkdNode &node = tree.getNode(nodeId);
-
-        // Do not consider nodes with a minimum distance greater than
-        // the distance estimate
-        double nodeMinDistance = node.evalPointMinDistance(point);
-        if (nodeMinDistance > distance) {
-        	toerase.push_back(nodeId);
-        }
+    switch(eltype){
+    case bitpit::ElementType::LINE:
+        checkBelong = mimmoCGUtils::isPointInsideSegment(point, vertCoords[0], vertCoords[1]);
+        break;
+    case bitpit::ElementType::TRIANGLE:
+        checkBelong = mimmoCGUtils::isPointInsideTriangle(point, vertCoords[0], vertCoords[1], vertCoords[2]);
+        break;
+    case bitpit::ElementType::PIXEL:
+    case bitpit::ElementType::QUAD:
+    case bitpit::ElementType::POLYGON:
+        checkBelong = mimmoCGUtils::isPointInsidePolygon(point, vertCoords);
+        break;
+    default:
+        throw std::runtime_error("Not supported cell type");
+        break;
+    }
+    if (checkBelong) {
+        id = cellId;
     }
 
-    for (long iderase : toerase){
-    	std::vector<std::size_t>::iterator it = std::find(m_candidateIds.begin(), m_candidateIds.end(), iderase);
-    	if (it != m_candidateIds.end())
-    		m_candidateIds.erase(it);
-    }
-
-    // Process the candidates and find which cell contains the point
-    for (std::size_t k = 0; k < m_candidateIds.size(); ++k) {
-
-        // Evaluate the min distance between all cells in the candidate node
-        std::size_t nodeId = m_candidateIds[k];
-        const bitpit::SkdNode &node = tree.getNode(nodeId);
-
-        bitpit::ElementType eltype ;
-        bool checkBelong;
-        for(const auto & cellId : node.getCells() ){
-            eltype = tree.getPatch().getCell(cellId).getType();
-            auto vList = tree.getPatch().getCell(cellId).getVertexIds();
-            dvecarr3E vertCoords(vList.size());
-            int counterList = 0;
-            for(const auto & idV : vList){
-                vertCoords[counterList] = tree.getPatch().getVertexCoords(idV);
-                ++counterList;
-            }
-
-            switch(eltype){
-                case bitpit::ElementType::LINE:
-                    checkBelong = mimmoCGUtils::isPointInsideSegment(point, vertCoords[0], vertCoords[1]);
-                    break;
-                case bitpit::ElementType::TRIANGLE:
-                    checkBelong = mimmoCGUtils::isPointInsideTriangle(point, vertCoords[0], vertCoords[1], vertCoords[2]);
-                    break;
-                case bitpit::ElementType::PIXEL:
-                case bitpit::ElementType::QUAD:
-                case bitpit::ElementType::POLYGON:
-                    checkBelong = mimmoCGUtils::isPointInsidePolygon(point, vertCoords);
-                    break;
-                default:
-                    throw std::runtime_error("Not supported cell type");
-                    break;
-            }
-            if (checkBelong) {
-                id       = cellId;
-                return id;
-            }
-        }
-    }
     return id;
 }
 
@@ -511,7 +498,723 @@ long closestCellToPoint(const std::array<double, 3> &point, bitpit::PatchSkdTree
     return id;
 }
 
+std::array<double, 3>
+computePseudoNormal(const std::array<double, 3> &point, const bitpit::SurfUnstructured *surface_mesh, long id)
+{
 
+    std::array<double, 3> pseudo_normal({0.,0.,0.});
+    double h;
+
+    //Pseudo normal only for 2D element patches
+    if (id != bitpit::Cell::NULL_ID){
+
+        const bitpit::Cell & cell = surface_mesh->getCell(id);
+        bitpit::ConstProxyVector<long> vertIds = cell.getVertexIds();
+        dvecarr3E VS(vertIds.size());
+        int count = 0;
+        for (const auto & iV: vertIds){
+            VS[count] = surface_mesh->getVertexCoords(iV);
+            ++count;
+        }
+
+        darray3E xP = {{0.0,0.0,0.0}};
+        darray3E normal= {{0.0,0.0,0.0}};
+
+        if ( vertIds.size() == 3 ){ //TRIANGLE
+            darray3E lambda;
+            h = bitpit::CGElem::distancePointTriangle(point, VS[0], VS[1], VS[2],lambda);
+            int count = 0;
+            for(const auto &val: lambda){
+                normal += val * surface_mesh->evalVertexNormal(id,count) ;
+                xP += val * VS[count];
+                ++count;
+            }
+        }else if ( vertIds.size() == 2 ){ //LINE/SEGMENT
+            darray2E lambda;
+            h = bitpit::CGElem::distancePointSegment(point, VS[0], VS[1], lambda);
+            int count = 0;
+            for(const auto &val: lambda){
+                normal += val * surface_mesh->evalVertexNormal(id,count) ;
+                xP += val * VS[count];
+                ++count;
+            }
+        }else{ //GENERAL POLYGON
+            std::vector<double> lambda;
+            h = bitpit::CGElem::distancePointPolygon(point, VS,lambda);
+            int count = 0;
+            for(const auto &val: lambda){
+                normal += val * surface_mesh->evalVertexNormal(id,count) ;
+                xP += val * VS[count];
+                ++count;
+            }
+        }
+
+        double s =  sign( dotProduct(normal, point - xP) );
+        if(s == 0.0)    s =1.0;
+        h = s * h;
+        //pseudo-normal (direction P and xP closest point on triangle)
+        pseudo_normal = s * (point - xP);
+        double normX = norm2(pseudo_normal);
+        if(normX < 1.E-15){
+            pseudo_normal = normal/norm2(normal);
+        }else{
+            pseudo_normal /= normX;
+        }
+    }//end if not id null
+
+    return pseudo_normal;
+}
+
+bool
+checkPointBelongsToCell(const std::array<double, 3> &point, const bitpit::SurfUnstructured *surface_mesh, long cellId)
+{
+    bool checkBelong = false;
+    bitpit::ElementType eltype = surface_mesh->getCell(cellId).getType();
+    auto vList = surface_mesh->getCell(cellId).getVertexIds();
+    dvecarr3E vertCoords(vList.size());
+    int counterList = 0;
+    for(const auto & idV : vList){
+        vertCoords[counterList] = surface_mesh->getVertexCoords(idV);
+        ++counterList;
+    }
+
+    switch(eltype){
+    case bitpit::ElementType::LINE:
+        checkBelong = mimmoCGUtils::isPointInsideSegment(point, vertCoords[0], vertCoords[1]);
+        break;
+    case bitpit::ElementType::TRIANGLE:
+        checkBelong = mimmoCGUtils::isPointInsideTriangle(point, vertCoords[0], vertCoords[1], vertCoords[2]);
+        break;
+    case bitpit::ElementType::PIXEL:
+    case bitpit::ElementType::QUAD:
+    case bitpit::ElementType::POLYGON:
+        checkBelong = mimmoCGUtils::isPointInsidePolygon(point, vertCoords);
+        break;
+    default:
+        throw std::runtime_error("Not supported cell type");
+        break;
+    }
+    return checkBelong;
+}
+
+#if MIMMO_ENABLE_MPI
+
+// TODO MULTIPLE POINTS VERSION TO OPTIMIZE COMMUNICATIONS
+
+/*!
+ * It computes the unsigned distance of a point to a geometry linked in a SkdTree
+ * object. The geometry has to be a surface mesh, in particular an object of type
+ * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
+ * It searches the element with minimum distance in a box of length 2*r, if none
+ * is found return a default value of distance equal to std::numeric_limits<double>::max();
+ * \param[in] nP Number of input points.
+ * \param[in] points Pointer to coordinates of input points.
+ * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
+ * \param[out] ids Labels of the elements found as minimum distance element in the bv-tree.
+ * \param[out] ranks Ranks of the process owner of the elements found as minimum distance elements in the bv-tree.
+ * \param[out] normals Pseudo-normals of the elements (i.e. unit vector with direction (P-xP),
+ * where P is the input point and xP the nearest point on the element (simplex) to
+ * the projection of P on the plane of the simplex.
+ * \param[out] distances Distance of the input points from the patch in the bv-tree.
+ * \param[in] shared True if the input points are shared between the processes
+ * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
+ * every element encountered inside the box/sphere).
+ */
+void globalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double r, bool shared)
+{
+
+    if(!tree ){
+        throw std::runtime_error("Invalid use of skdTreeUtils::distance method: a void tree is detected.");
+    }
+    if(!dynamic_cast<const bitpit::SurfUnstructured*>(&(tree->getPatch()))){
+        throw std::runtime_error("Invalid use of skdTreeUtils::distance method: a not surface patch tree is detected.");
+    }
+
+    if (shared){
+        static_cast<const bitpit::SurfaceSkdTree*>(tree)->findPointClosestGlobalCell(nP, points, r, ids, ranks, distances);
+    } else {
+        static_cast<const bitpit::SurfaceSkdTree*>(tree)->findPointClosestGlobalCell(nP, points, r, ids, ranks, distances);
+    }
+
+}
+
+/*!
+ * It computes the signed global distance of a set of points to a geometry linked in a SkdTree
+ * object. The geometry must be a surface mesh, in particular an object of type
+ * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
+ * The sign of the distance is provided by the normal to the geometry locally
+ * computed. A positive distance means that the point is located, in respect to the
+ * surface mesh, on the same side of the outer normal vector.
+ * It searches the element with minimum distance in a box of length 2*r, if none
+ * is found return a default value of distance equal to std::numeric_limits<double>::max();
+ * \param[in] nP Number of input points.
+ * \param[in] points Pointer to coordinates of input points.
+ * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
+ * \param[out] ids Labels of the elements found as minimum distance element in the bv-tree.
+ * \param[out] ranks Ranks of the process owner of the elements found as minimum distance elements in the bv-tree.
+ * \param[out] normals Pseudo-normals of the elements (i.e. unit vector with direction (P-xP),
+ * where P is the input point and xP the nearest point on the element (simplex) to
+ * the projection of P on the plane of the simplex.
+ * \param[out] distances Signed distance of the input points from the patch in the bv-tree.
+ * \param[in] shared True if the input points are shared between the processes
+ * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
+ * every element encountered inside the box/sphere).
+ */
+void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, std::array<double,3> *normals, double *distances, double r, bool shared)
+{
+
+    if(!tree){
+        throw std::runtime_error("Invalid use of skdTreeUtils::signedDistance method: a void tree is detected.");
+    }
+    const bitpit::SurfUnstructured & spatch = static_cast<const bitpit::SurfUnstructured&>(tree->getPatch());
+
+    if (shared){
+        // All processes share the points
+        static_cast<const bitpit::SurfaceSkdTree*>(tree)->findPointClosestGlobalCell(nP, points, r, ids, ranks, distances);
+    } else {
+        // Distributed points
+        static_cast<const bitpit::SurfaceSkdTree*>(tree)->findPointClosestGlobalCell(nP, points, r, ids, ranks, distances);
+    }
+
+    int myrank = spatch.getRank();
+
+    // Map with rank to ask info in case of distributed points
+    std::map<int,std::vector<long>> ask_to_rank;
+    std::map<int,std::vector<std::array<double,3>>> point_to_rank;
+    std::map<int,std::vector<std::size_t>> point_index_received_from_rank;
+
+    // Loop on points
+    for (std::size_t ip = 0; ip < nP; ip++){
+
+        const std::array<double,3> & point = points[ip];
+        const long & cellId = ids[ip];
+        const int & cellRank = ranks[ip];
+        double & distance = distances[ip];
+        std::array<double,3> & pseudo_normal = normals[ip];
+
+        // If the current rank is the the owner of the cell compute normal
+        if (cellRank == myrank){
+
+            pseudo_normal = computePseudoNormal(point, &spatch, cellId);
+
+        } else {
+
+            // If not owner fix the normal to maximum value
+            pseudo_normal = std::array<double,3>({std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max()});
+
+            if (!shared){
+                // Push to rank map to ask normal
+                ask_to_rank[cellRank].push_back(cellId);
+
+                // Push to rank map the related points to ask normal
+                point_to_rank[cellRank].push_back(point);
+
+                // Push to rank map the index of the points to fill output normals
+                point_index_received_from_rank[cellRank].push_back(ip);
+            }
+
+        } // end if owner rank
+
+    } // end loop on points
+
+    int nProcessors = spatch.getProcessorCount();
+
+    if (nProcessors > 1 && spatch.isPartitioned()){
+        if (shared){
+
+            // If all points are shared between processes all reduce on normal by minimum operation
+            MPI_Allreduce(MPI_IN_PLACE, normals, 3*nP, MPI_DOUBLE, MPI_MIN, tree->getCommunicator());
+
+        } else {
+
+            // Send/receive number of normals to send to other processes
+            std::vector<std::size_t> n_send_to_rank(nProcessors, 0);
+            for (int irank = 0; irank < nProcessors; irank++){
+                std::size_t n_ask_to_current_rank = ask_to_rank[irank].size();
+                MPI_Gather(&n_ask_to_current_rank, 1, MPI_LONG, n_send_to_rank.data(), 1, MPI_LONG, irank, tree->getCommunicator());
+            }
+
+            // Map with rank to send info for cellId and point coordinates
+            std::map<int,std::vector<long>> send_to_rank;
+            std::map<int,std::vector<std::array<double,3>>> point_from_rank;
+            for (int irank = 0; irank < nProcessors; irank++){
+                send_to_rank[irank].resize(n_send_to_rank[irank], bitpit::Cell::NULL_ID);
+                point_from_rank[irank].resize(n_send_to_rank[irank], std::array<double,3>({{0.,0.,0.}}));
+            }
+
+            // Recover id of the cell and points on which compute the pseudonormal
+            for (int irank = 0; irank < nProcessors; irank++){
+                if (myrank == irank){
+                    for (int jrank = 0; jrank < nProcessors; jrank++){
+                        if (jrank != irank){
+                            std::size_t n_send_to_current_rank = n_send_to_rank[jrank];
+                            MPI_Recv(send_to_rank[jrank].data(), n_send_to_current_rank, MPI_LONG, jrank, 100, tree->getCommunicator(), MPI_STATUS_IGNORE);
+                            MPI_Recv(point_from_rank[jrank].data(), n_send_to_current_rank*3, MPI_DOUBLE, jrank, 101, tree->getCommunicator(), MPI_STATUS_IGNORE);
+                        }
+                    }
+                } else {
+                    std::size_t n_ask_to_current_rank = ask_to_rank[irank].size();
+                    MPI_Send(ask_to_rank[irank].data(), n_ask_to_current_rank, MPI_LONG, irank, 100, tree->getCommunicator());
+                    MPI_Send(point_to_rank[irank].data(), n_ask_to_current_rank*3, MPI_DOUBLE, irank, 101, tree->getCommunicator());
+                }
+            }
+
+            // Compute pseudo-normal for each received point from each rank
+            std::map<int, std::vector<std::array<double,3>>> normal_to_rank;
+            for (std::size_t irank = 0; irank < nProcessors; irank++){
+                normal_to_rank[irank].resize(n_send_to_rank[irank], std::array<double,3>({std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max()}));
+                for (std::size_t ip = 0; ip < n_send_to_rank[irank]; ip++){
+
+                    const std::array<double,3> & point = point_from_rank[irank][ip];
+                    const long & cellId = send_to_rank[irank][ip];
+                    std::array<double,3> & pseudo_normal = normal_to_rank[irank][ip];
+
+                    pseudo_normal = computePseudoNormal(point, &spatch, cellId);
+
+                } // end loop on points received
+            }  // end loop on ranks
+
+            // Communicate back the computed pseudonormals
+            std::map<int, std::vector<std::array<double,3>>> normal_from_rank;
+
+            for (int irank = 0; irank < nProcessors; irank++){
+                if (myrank == irank){
+                    for (int jrank = 0; jrank < nProcessors; jrank++){
+                        if (jrank != irank){
+                            std::size_t n_ask_to_current_rank = ask_to_rank[jrank].size();
+                            normal_from_rank[jrank].resize(n_ask_to_current_rank);
+                            MPI_Recv(normal_from_rank[jrank].data(), n_ask_to_current_rank*3, MPI_DOUBLE, jrank, 102, tree->getCommunicator(), MPI_STATUS_IGNORE);
+
+                            // Fill normals output with the correct received pseudonormals (TODO move out of communications scope?)
+                            for (std::size_t ip = 0; ip < n_ask_to_current_rank; ip++){
+                                std::size_t point_index = point_index_received_from_rank[jrank][ip];
+                                normals[point_index] = normal_from_rank[jrank][ip];
+                            }
+
+                        }
+                    }
+                } else {
+                    std::size_t n_send_to_current_rank = n_send_to_rank[irank];
+                    MPI_Send(normal_to_rank[irank].data(), n_send_to_current_rank*3, MPI_DOUBLE, irank, 102, tree->getCommunicator());
+                }
+            }
+
+        } // end if not shared points
+    }
+}
+
+/*!
+ * It computes the projection of a set of points on a geometry linked in a skdtree
+ * object. The geometry must be a surface mesh, in particular an object of type
+ * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
+ * It searches the elements of the geometry with minimum distance
+ * recursively in a sphere of radius r, by increasing the size r at each step
+ * until at least one element is found.
+ * \param[in] nP Number of input points.
+ * \param[in] points Pointer to coordinates of input points.
+ * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
+ * \param[out] ids Labels of the elements found as minimum distance element into the points are projected.
+ * \param[out] ranks Ranks of the process owner of the elements into the points are projected.
+ * \param[in] r Initial length of the sphere radius used to search. (The algorithm checks
+ * every element encountered inside the sphere).
+ * \param[out] Coordinates of the projected points.
+ */
+void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, int *ranks, double r, bool shared )
+{
+
+    // Initialize ids and ranks
+    for (std::size_t ip = 0; ip < nP; ip++){
+        ids[ip] = bitpit::Cell::NULL_ID;
+        ranks[ip] = -1;
+    }
+    std::vector<darray3E>    normals(nP);
+
+    r = std::max(r, tree->getPatch().getTol());
+
+    std::vector<double> dist(nP, std::numeric_limits<double>::max());
+    double max_dist = std::numeric_limits<double>::max();
+    while (max_dist >= std::numeric_limits<double>::max()){
+        //use method sphere by default
+        signedGlobalDistance(nP, points, tree, ids, ranks, normals.data(), dist.data(), r, shared);
+        r *= 1.5;
+        max_dist = std::abs(*std::max_element(dist.begin(), dist.end()));
+        max_dist = std::max(max_dist, std::abs(*std::min_element(dist.begin(), dist.end())));
+    }
+
+    for (std::size_t ip = 0; ip < nP; ip++){
+        projected_points[ip] = points[ip] - dist[ip] * normals[ip];
+    }
+}
+
+/*!
+ * Given the specified set of points find the cells of a surface patch it is into.
+ * The method works only with trees generated with bitpit::SurfUnstructured mesh.
+ *
+ * \param[in] nP Number of input points
+ * \param[in] points is the set of points
+ * \param[in] tree reference to SkdTree relative to the target surface geometry.
+ * \param[out] ids of the geometry cells the points is into. Return bitpit::Cell::NULL_ID if no cell is found.
+ * \param[out] ranks Ranks of the process owner of the elements found as location of the points.
+ * \param[in] shared True if the input points are shared between the processes
+ */
+void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, bool shared)
+{
+    if(!dynamic_cast<const bitpit::SurfUnstructured*>(&(tree->getPatch()))){
+        throw std::runtime_error("Invalid use of skdTreeUtils::locatePointOnPatch method: a non surface patch or void patch was detected.");
+    }
+    const bitpit::SurfUnstructured & spatch = static_cast<const bitpit::SurfUnstructured&>(tree->getPatch());
+
+    // Initialize the cell id and distance
+    for (std::size_t ip = 0; ip < nP; ip++){
+        ids[ip] = bitpit::Cell::NULL_ID;
+    }
+    std::vector<double> distances(nP, std::numeric_limits<double>::max());
+
+    // Find the closest cell to the input point
+    std::vector<long> cellIds(nP, bitpit::Cell::NULL_ID);
+    std::vector<int> cellRanks(nP, -1);
+    if (shared){
+        // All processes share the points
+        static_cast<const bitpit::SurfaceSkdTree*>(tree)->findPointClosestGlobalCell(nP, points, cellIds.data(), ranks, distances.data());
+    } else {
+        // Distributed points
+        static_cast<const bitpit::SurfaceSkdTree*>(tree)->findPointClosestGlobalCell(nP, points, cellIds.data(), ranks, distances.data());
+    }
+
+    int myrank = spatch.getRank();
+
+    // Map with rank to ask info in case of distributed points
+    std::map<int,std::vector<long>> ask_to_rank;
+    std::map<int,std::vector<std::array<double,3>>> point_to_rank;
+    std::map<int,std::vector<std::size_t>> point_index_received_from_rank;
+
+    // Loop on points
+    for (std::size_t ip = 0; ip < nP; ip++){
+
+        const std::array<double,3> & point = points[ip];
+        const long & cellId = cellIds[ip];
+        const int & cellRank = ranks[ip];
+        double & distance = distances[ip];
+
+        // If the current rank is the the owner of the cell check if the point belongs to the closest cell
+        if (cellRank == myrank){
+
+            bool checkBelong = checkPointBelongsToCell(point, &spatch, cellId);
+
+            if (checkBelong) {
+                ids[ip] = cellId;
+            }
+
+        } else {
+
+            // If not owner maintain the Cell::NULL_ID value, equal to minimum long int for bitpit::Cell
+
+            if (!shared){
+
+                // Push to rank map to ask normal
+                ask_to_rank[cellRank].push_back(cellId);
+
+                // Push to rank map the related points to ask normal
+                point_to_rank[cellRank].push_back(point);
+
+                // Push to rank map the index of the points to fill output normals
+                point_index_received_from_rank[cellRank].push_back(ip);
+
+            }
+
+        } // end if owner rank
+
+    } // End loop on points
+
+    int nProcessors = spatch.getProcessorCount();
+
+    if (nProcessors > 1 && spatch.isPartitioned()){
+        if (shared){
+
+            // If all points are shared between processes all reduce on ids by maximum operation
+            MPI_Allreduce(MPI_IN_PLACE, ids, nP, MPI_LONG, MPI_MAX, tree->getCommunicator());
+
+        } else {
+
+            // Send/receive number of check belong to send to other processes
+            std::vector<std::size_t> n_send_to_rank(nProcessors, 0);
+            for (int irank = 0; irank < nProcessors; irank++){
+                std::size_t n_ask_to_current_rank = ask_to_rank[irank].size();
+                MPI_Gather(&n_ask_to_current_rank, 1, MPI_LONG, n_send_to_rank.data(), 1, MPI_LONG, irank, tree->getCommunicator());
+            }
+
+            // Map with rank to send info for cellId and point coordinates
+            std::map<int,std::vector<long>> send_to_rank;
+            std::map<int,std::vector<std::array<double,3>>> point_from_rank;
+            for (int irank = 0; irank < nProcessors; irank++){
+                send_to_rank[irank].resize(n_send_to_rank[irank], bitpit::Cell::NULL_ID);
+                point_from_rank[irank].resize(n_send_to_rank[irank], std::array<double,3>({{0.,0.,0.}}));
+            }
+
+            // Recover id of the cell and points on which check the belonging
+            for (int irank = 0; irank < nProcessors; irank++){
+                if (myrank == irank){
+                    for (int jrank = 0; jrank < nProcessors; jrank++){
+                        if (jrank != irank){
+                            std::size_t n_send_to_current_rank = n_send_to_rank[jrank];
+                            MPI_Recv(send_to_rank[jrank].data(), n_send_to_current_rank, MPI_LONG, jrank, 100, tree->getCommunicator(), MPI_STATUS_IGNORE);
+                            MPI_Recv(point_from_rank[jrank].data(), n_send_to_current_rank*3, MPI_DOUBLE, jrank, 101, tree->getCommunicator(), MPI_STATUS_IGNORE);
+                        }
+                    }
+                } else {
+                    std::size_t n_ask_to_current_rank = ask_to_rank[irank].size();
+                    MPI_Send(ask_to_rank[irank].data(), n_ask_to_current_rank, MPI_LONG, irank, 100, tree->getCommunicator());
+                    MPI_Send(point_to_rank[irank].data(), n_ask_to_current_rank*3, MPI_DOUBLE, irank, 101, tree->getCommunicator());
+                }
+            }
+
+            // Check if the point belong to cell for each received point from each rank
+            std::map<int, std::vector<int>> checkBelong_to_rank;
+            for (std::size_t irank = 0; irank < nProcessors; irank++){
+                checkBelong_to_rank[irank].resize(n_send_to_rank[irank], false);
+                for (std::size_t ip = 0; ip < n_send_to_rank[irank]; ip++){
+
+                    const std::array<double,3> & point = point_from_rank[irank][ip];
+                    const long & cellId = send_to_rank[irank][ip];
+                    int & checkBelong = checkBelong_to_rank[irank][ip];
+
+                    checkBelong = int(checkPointBelongsToCell(point, &spatch, cellId));
+
+                } // end loop on points received
+            }  // end loop on ranks
+
+            // Communicate back the computed cehck belong
+            std::map<int, std::vector<int>> checkBelong_from_rank;
+
+            for (int irank = 0; irank < nProcessors; irank++){
+                if (myrank == irank){
+                    for (int jrank = 0; jrank < nProcessors; jrank++){
+                        if (jrank != irank){
+                            std::size_t n_ask_to_current_rank = ask_to_rank[jrank].size();
+                            checkBelong_from_rank[jrank].resize(n_ask_to_current_rank);
+                            MPI_Recv(checkBelong_from_rank[jrank].data(), n_ask_to_current_rank, MPI_INT, jrank, 102, tree->getCommunicator(), MPI_STATUS_IGNORE);
+
+                            // Fill cell ids output if the received check belong is true (TODO move out of communications scope?)
+                            for (std::size_t ip = 0; ip < n_ask_to_current_rank; ip++){
+                                std::size_t point_index = point_index_received_from_rank[jrank][ip];
+                                long cellId = ask_to_rank[jrank][ip];
+                                // Check received int value (zero or one) casting to boolean
+                                if (bool(checkBelong_from_rank[jrank][ip])) {
+                                    ids[point_index] = cellId;
+                                }
+                            }
+
+                        }
+                    }
+                } else {
+                    std::size_t n_send_to_current_rank = n_send_to_rank[irank];
+                    MPI_Send(checkBelong_to_rank[irank].data(), n_send_to_current_rank, MPI_INT, irank, 102, tree->getCommunicator());
+                }
+            }
+
+        } // end if not shared points
+    }
+}
+
+/*!
+ * It selects the elements of a geometry stored in a skdtree by a distance criterion
+ * in respect to an other global geometry stored in a different global skdtree.
+ * \param[in] selection Pointer to bv-tree used as selection patch.
+ * \param[in] target Pointer to bv-tree that store the target geometry.
+ * \param[in] tol Distance threshold used to select the elements of target.
+ * \return Vector of the label of all the local (current rank) elements of the target skdtree placed
+ * at a distance <= tol from the bounding boxes of the leaf nodes of the global skdtree
+ * selection.
+ */
+std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol){
+
+    if (!target->getPatch().isPartitioned()){
+        return(selectByPatch(selection, target, tol));
+    }
+
+    // Leaf selection nodes of current rank initialized for each rank of target bounding box
+    int nprocs = target->getPatch().getProcessorCount();
+    int myRank = target->getPatch().getRank();
+    std::size_t nleafs = selection->getLeafCount();
+    std::size_t nnodess = selection->getNodeCount();
+    std::unordered_map<int, std::vector<const bitpit::SkdNode*>> rankLeafSelection;
+    for (int irank = 0; irank < nprocs; irank++){
+        std::vector<const bitpit::SkdNode*> leafSelection(nleafs);
+        int count = 0;
+        for (int i=0; i<nnodess; i++){
+            if (selection->getNode(i).isLeaf()){
+                if (bitpit::CGElem::intersectBoxBox(selection->getNode(i).getBoxMin()-tol,
+                        selection->getNode(i).getBoxMax()+tol,
+                        target->getPartitionBoxMin(irank),
+                        target->getPartitionBoxMax(irank) ) ){
+                    leafSelection[count] = &(selection->getNode(i));
+                    count++;
+
+                }
+            }
+        }
+        leafSelection.resize(count);
+        rankLeafSelection[irank].swap(leafSelection);
+    }
+
+    // Collect all the leaf selection SkdBox bounding boxes from each process in the map structure
+    // Collect and store from other processes the leaf selection bounding boxes for the current target rank
+    std::vector<bitpit::SkdBox> leafSelectionBoxes;
+
+    // Recover the number of selection elements of each process for each target process
+    // This is the number of elements sent and received to/from each process from/to each process
+    std::vector<int> nLeafSend(nprocs, 0);
+    std::vector<int> nLeafRecv(nprocs, 0);
+    for (int irank = 0; irank < nprocs; irank++){
+        nLeafSend[irank] = rankLeafSelection[irank].size();
+    }
+
+    for (int irank = 0; irank < nprocs; irank++){
+        // Scatter send to all process of irank process data
+        int * recvbuff = &nLeafRecv[irank];
+        MPI_Scatter(nLeafSend.data(), 1, MPI_INT, recvbuff, 1, MPI_INT, irank, MPI_COMM_WORLD);
+    }
+
+    // Recover global leaf received to resize local received boxes container
+    int nGlobalReceived = 0;
+    for (int val : nLeafRecv){
+        nGlobalReceived += val;
+    }
+
+    if (nGlobalReceived > 0){
+        leafSelectionBoxes.reserve(nGlobalReceived);
+    }
+
+    // Communicate minimum and maximum point of each leaf bounding box to the right process
+    // Gather bounding boxes for each process by communicating minimum and maximum point
+    // coordinates as vector of 6 coordinates for each box
+    std::vector<double> recvBoxes;
+    for (int irank = 0; irank < nprocs; irank++){
+        int nSendData = 0;
+        std::vector<double> sendBoxes;
+        int nRecvData = 0;
+        std::vector<int> recvDispls(nprocs, 0);
+        std::vector<int> nRecvDataPerProc(nprocs, 0);
+        if (irank == myRank){
+            // If root is current rank set receive buffer
+            nRecvData = 6 * nGlobalReceived;
+            recvBoxes.resize(nRecvData, std::numeric_limits<double>::max());
+            // Set receiving displacements to gather bounding boxes
+            nRecvDataPerProc[0] = nLeafRecv[0] * 6;
+            for (int jrank = 1; jrank < nprocs; jrank++){
+                recvDispls[jrank] = recvDispls[jrank - 1] + nLeafRecv[jrank - 1] * 6;
+                nRecvDataPerProc[jrank] = nLeafRecv[jrank] * 6;
+            }
+        }
+        // Set send buffer for all processes even for root
+        nSendData = 6 * nLeafSend[irank];
+        sendBoxes.reserve(nSendData);
+        for (const bitpit::SkdNode* selectNode : rankLeafSelection[irank]){
+            for (const double val : selectNode->getBoxMin()){
+                sendBoxes.push_back(val);
+            }
+            for (const double val : selectNode->getBoxMax()){
+                sendBoxes.push_back(val);
+            }
+        }
+
+        // Gather bounding boxes points to the root process
+        MPI_Gatherv(sendBoxes.data(), nSendData, MPI_DOUBLE, recvBoxes.data(), nRecvDataPerProc.data(), recvDispls.data(), MPI_DOUBLE, irank, target->getCommunicator());
+
+    } // End loop on root processes
+
+    // Fill leaf selection boxes container
+    std::vector<double>::iterator itBox = recvBoxes.begin();
+    for (std::size_t ibox = 0; ibox < nGlobalReceived; ibox++){
+        std::array<double, 3> minPoint;
+        minPoint[0] = *(itBox++);
+        minPoint[1] = *(itBox++);
+        minPoint[2] = *(itBox++);
+        std::array<double, 3> maxPoint;
+        maxPoint[0] = *(itBox++);
+        maxPoint[1] = *(itBox++);
+        maxPoint[2] = *(itBox++);
+        leafSelectionBoxes.emplace_back(bitpit::SkdBox(minPoint, maxPoint));
+    }
+
+    std::vector<long> extracted;
+    extractTarget(target, leafSelectionBoxes, extracted, tol);
+
+    return extracted;
+
+}
+
+/*!
+ * It extracts the elements of a leaf node of geometry stored in a skdtree
+ * by a distance criterion in respect to an other geometry stored
+ * in a different skdtree and passed as vector of bounding boxes. It is a method used in selectByGlobalPatch method.
+ * \param[in] target Pointer to skdtree that store the target geometry.
+ * \param[in] leafSelection Vector of bounding boxes SkdBox of the leaf nodes currently interesting
+ * for the selection procedure.
+ * \param[in,out] extracted of the label of all the elements of the target skdtree,
+ * currently found placed at a distance <= tol from the bounding boxes of the
+ * leaf nodes in leafSelection.
+ * \param[in] tol Distance threshold used to select the elements of target.
+ * the next-th node is not a leaf node the method is recursively called.
+ *
+ *
+ */
+void extractTarget(bitpit::PatchSkdTree *target, const std::vector<bitpit::SkdBox> &leafSelectionBoxes, std::vector<long> &extracted, double tol)
+{
+
+    if(leafSelectionBoxes.empty()) return;
+    std::size_t rootId = 0;
+
+    // Candidates saved in set to avoid duplicate
+    std::unordered_set<std::size_t> candidates;
+
+    // Loop on leaf selection boxes and go across the target tree with a node stack
+    for (const bitpit::SkdBox & selectionBox : leafSelectionBoxes){
+
+        // Initialize stack with target root node
+        std::queue<std::size_t> nodeStack;
+        nodeStack.push(rootId);
+
+        // Pop and push target tree nodes checked with current selection boxe
+        // Fill candidates structure with leaf target nodes intersected by selection box
+        // Stop when stack is empty
+        while(!nodeStack.empty()){
+
+            std::size_t nodeId = nodeStack.front();
+            nodeStack.pop();
+            const bitpit::SkdNode & node = target->getNode(nodeId);
+
+            bool isLeaf = true;
+            for (int i = bitpit::SkdNode::CHILD_BEGIN; i != bitpit::SkdNode::CHILD_END; ++i) {
+                bitpit::SkdNode::ChildLocation childLocation = static_cast<bitpit::SkdNode::ChildLocation>(i);
+                std::size_t childId = node.getChildId(childLocation);
+                if (childId != bitpit::SkdNode::NULL_ID) {
+                    isLeaf = false;
+                    if (bitpit::CGElem::intersectBoxBox(selectionBox.getBoxMin()-tol, selectionBox.getBoxMax()+tol,
+                                target->getNode(childId).getBoxMin(), target->getNode(childId).getBoxMax())){
+                        nodeStack.push(childId);
+                    }
+                }
+            }
+            if (isLeaf) {
+                candidates.insert(nodeId);
+            }
+        }
+    } // End loop on selection boxes
+
+    // Extract cell from candidates nodes
+    // Do not check for intersection -> exctraction performed only by using bounding boxes of leaf nodes of the skd-trees
+    std::unordered_set<long> cellExtracted;
+    for(std::size_t nodeId : candidates){
+        const bitpit::SkdNode & node = target->getNode(nodeId);
+        std::vector<long> cellids = node.getCells();
+        cellExtracted.insert(cellids.begin(), cellids.end());
+    }
+
+    extracted.insert(extracted.end(), cellExtracted.begin(), cellExtracted.end());
+}
+
+#endif
 
 }
 

--- a/src/core/SkdTreeUtils.cpp
+++ b/src/core/SkdTreeUtils.cpp
@@ -1116,12 +1116,14 @@ void locatePointOnGlobalPatch(int nP, const std::array<double,3> *points, const 
  */
 std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol){
 
-    if (!selection->getPatch().isCommunicatorSet() || !target->getPatch().isCommunicatorSet()){
-        throw std::runtime_error("Error: at least one PatchSkdTree communicator not set in selectByGlobalPatch");
+    if (!selection->getPatch().isPartitioned() || !target->getPatch().isPartitioned()){
+        throw std::runtime_error("Error: the two PatchSkdTree communicators not set in selectByGlobalPatch");
     }
-    if (!selection->getPatch().isPartitioned() && !target->getPatch().isPartitioned()){
-        return(selectByPatch(selection, target, tol));
-    }
+
+    //TODO USE THE REAL IS DISTRIBUTED PATCH IN BITPIT WHEN READY !!!!
+//    if (!selection->getPatch().isPartitioned() && !target->getPatch().isPartitioned()){
+//        return(selectByPatch(selection, target, tol));
+//    }
 
     // Leaf selection nodes of current rank initialized for each rank of target bounding box
     int nprocs = selection->getPatch().getProcessorCount();

--- a/src/core/SkdTreeUtils.cpp
+++ b/src/core/SkdTreeUtils.cpp
@@ -562,7 +562,7 @@ computePseudoNormal(const std::array<double, 3> &point, const bitpit::SurfUnstru
         //pseudo-normal (direction P and xP closest point on triangle)
         pseudo_normal = s * (point - xP);
         double normX = norm2(pseudo_normal);
-        if(normX < 1.E-15){
+        if(normX < surface_mesh->getTol()){
             pseudo_normal = normal/norm2(normal);
         }else{
             pseudo_normal /= normX;

--- a/src/core/SkdTreeUtils.cpp
+++ b/src/core/SkdTreeUtils.cpp
@@ -117,7 +117,7 @@ double signedDistance(const std::array<double,3> *point, const bitpit::PatchSkdT
  * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
  * every element encountered inside the box/sphere).
  */
-void distance(size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, double *distances, double r)
+void distance(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, double *distances, double r)
 {
     std::vector<double> rs(nP, r);
     distance(nP, points, tree, ids, distances, rs.data());
@@ -138,11 +138,11 @@ void distance(size_t nP, const std::array<double,3> *points, const bitpit::Patch
  * \param[in] r Length of the side of the box or radius of the sphere used to search for each
  * input point. (The algorithm checks every element encountered inside the box/sphere).
  */
-void distance(size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, double *distances, double *r)
+void distance(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, double *distances, double *r)
 {
 
     // Initialize distances
-    for (std::size_t ip = 0; ip < nP; ip++){
+    for (int ip = 0; ip < nP; ip++){
         distances[ip] = std::numeric_limits<double>::max();
     }
 
@@ -153,7 +153,7 @@ void distance(size_t nP, const std::array<double,3> *points, const bitpit::Patch
         throw std::runtime_error("Invalid use of skdTreeUtils::distance method: a not surface patch tree is detected.");
     }
 
-    for (std::size_t ip = 0; ip < nP; ip++){
+    for (int ip = 0; ip < nP; ip++){
         const std::array<double,3> *point = &points[ip];
         long *id = &ids[ip];
         double *distance = &distances[ip];
@@ -184,7 +184,7 @@ void distance(size_t nP, const std::array<double,3> *points, const bitpit::Patch
  * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
  * every element encountered inside the box/sphere).
  */
-void signedDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, double *distances, std::array<double,3> *normals, double r)
+void signedDistance(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, double *distances, std::array<double,3> *normals, double r)
 {
     std::vector<double> rs(nP, r);
     signedDistance(nP, points, tree, ids, distances, normals, rs.data());
@@ -211,11 +211,11 @@ void signedDistance(std::size_t nP, const std::array<double,3> *points, const bi
  * \param[in] r Length of the side of the box or radius of the sphere used to search for each input
  * point. (The algorithm checks every element encountered inside the box/sphere).
  */
-void signedDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, double *distances, std::array<double,3> *normals, double *r)
+void signedDistance(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, double *distances, std::array<double,3> *normals, double *r)
 {
 
     // Initialize distances
-    for (std::size_t ip = 0; ip < nP; ip++){
+    for (int ip = 0; ip < nP; ip++){
         distances[ip] = std::numeric_limits<double>::max();
     }
 
@@ -227,7 +227,7 @@ void signedDistance(std::size_t nP, const std::array<double,3> *points, const bi
         throw std::runtime_error("Invalid use of skdTreeUtils::signedDistance method: a not surface patch tree is detected.");
     }
 
-    for (std::size_t ip = 0; ip < nP; ip++){
+    for (int ip = 0; ip < nP; ip++){
         const std::array<double,3> *point = &points[ip];
         long *id = &ids[ip];
         double *distance = &distances[ip];
@@ -294,10 +294,10 @@ std::vector<long> selectByPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSk
 void extractTarget(bitpit::PatchSkdTree *target, const std::vector<const bitpit::SkdNode*> & leafSelection, std::vector<long> &extracted, double tol){
 
     if(leafSelection.empty())   return;
-    std::size_t rootId = 0;
+    long rootId = 0;
 
-    std::vector<std::size_t> candidates;
-    std::vector<std::pair< std::size_t, std::vector<const bitpit::SkdNode*> > > nodeStack;
+    std::vector<long> candidates;
+    std::vector<std::pair< long, std::vector<const bitpit::SkdNode*> > > nodeStack;
 
     std::vector<const bitpit::SkdNode*> tocheck;
     for (int i=0; i<(int)leafSelection.size(); i++){
@@ -313,7 +313,7 @@ void extractTarget(bitpit::PatchSkdTree *target, const std::vector<const bitpit:
 
     while(!nodeStack.empty()){
 
-        std::pair<std::size_t,  std::vector<const bitpit::SkdNode*> >  touple = nodeStack.back();
+        std::pair<long,  std::vector<const bitpit::SkdNode*> >  touple = nodeStack.back();
         const bitpit::SkdNode & node = target->getNode(touple.first);
         nodeStack.pop_back();
 
@@ -321,7 +321,7 @@ void extractTarget(bitpit::PatchSkdTree *target, const std::vector<const bitpit:
         bool isLeaf = true;
         for (int i = bitpit::SkdNode::CHILD_BEGIN; i != bitpit::SkdNode::CHILD_END; ++i) {
             bitpit::SkdNode::ChildLocation childLocation = static_cast<bitpit::SkdNode::ChildLocation>(i);
-            std::size_t childId = node.getChildId(childLocation);
+            long childId = node.getChildId(childLocation);
             if (childId != bitpit::SkdNode::NULL_ID) {
                 isLeaf = false;
                 tocheck.clear();
@@ -389,7 +389,7 @@ darray3E projectPoint(const std::array<double,3> *point, const bitpit::PatchSkdT
  * every element encountered inside the sphere).
  * \param[out] Coordinates of the projected points.
  */
-void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double r )
+void projectPoint(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double r )
 {
     std::vector<double> rs(nP, r);
     projectPoint(nP, points, tree, projected_points, ids, rs.data());
@@ -410,11 +410,11 @@ void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitp
  * every element encountered inside the sphere).
  * \param[out] Coordinates of the projected points.
  */
-void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double *r )
+void projectPoint(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double *r )
 {
 
     // Initialize ids and ranks
-    for (std::size_t ip = 0; ip < nP; ip++){
+    for (int ip = 0; ip < nP; ip++){
         ids[ip] = bitpit::Cell::NULL_ID;
         r[ip] = std::max(r[ip], tree->getPatch().getTol());
     }
@@ -425,7 +425,7 @@ void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitp
     while (max_dist == std::numeric_limits<double>::max()){
         //use method sphere by default
         signedDistance(nP, points, tree, ids, dist.data(), normals.data(), r);
-        for (std::size_t ip = 0; ip < nP; ip++){
+        for (int ip = 0; ip < nP; ip++){
             if (std::abs(dist[ip]) >= max_dist){
                 r[ip] *= 1.5;
             }
@@ -434,7 +434,7 @@ void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitp
         max_dist = std::max(max_dist, std::abs(*std::min_element(dist.begin(), dist.end())));
     }
 
-    for (std::size_t ip = 0; ip < nP; ip++){
+    for (int ip = 0; ip < nP; ip++){
         projected_points[ip] = points[ip] - dist[ip] * normals[ip];
     }
 }
@@ -626,7 +626,7 @@ checkPointBelongsToCell(const std::array<double, 3> &point, const bitpit::SurfUn
  * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
  * every element encountered inside the box/sphere).
  */
-void globalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double r, bool shared)
+void globalDistance(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double r, bool shared)
 {
     std::vector<double> rs(nP, r);
     globalDistance(nP, points, tree, ids, ranks, distances, rs.data(), shared);
@@ -645,7 +645,7 @@ void globalDistance(std::size_t nP, const std::array<double,3> *points, const bi
  * \param[in] r Length of the side of the box or radius of the sphere used to search for each input point (The algorithm checks
  * every element encountered inside the box/sphere).
  */
-void globalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double* r, bool shared)
+void globalDistance(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double* r, bool shared)
 {
 
     if(!tree ){
@@ -679,7 +679,7 @@ void globalDistance(std::size_t nP, const std::array<double,3> *points, const bi
  * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
  * every element encountered inside the box/sphere).
  */
-void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, std::array<double,3> *normals, double *distances, double r, bool shared)
+void signedGlobalDistance(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, std::array<double,3> *normals, double *distances, double r, bool shared)
 {
     std::vector<double> rs(nP, r);
     signedGlobalDistance(nP, points, tree, ids, ranks, normals, distances, rs.data(), shared);
@@ -701,7 +701,7 @@ void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, co
  * \param[in] r Length of the side of the box or radius of the sphere used to search for each input point. (The algorithm checks
  * every element encountered inside the box/sphere).
  */
-void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, std::array<double,3> *normals, double *distances, double *r, bool shared)
+void signedGlobalDistance(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, std::array<double,3> *normals, double *distances, double *r, bool shared)
 {
 
     if(!tree){
@@ -722,10 +722,10 @@ void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, co
     // Map with rank to ask info in case of distributed points
     std::map<int,std::vector<long>> ask_to_rank;
     std::map<int,std::vector<std::array<double,3>>> point_to_rank;
-    std::map<int,std::vector<std::size_t>> point_index_received_from_rank;
+    std::map<int,std::vector<int>> point_index_received_from_rank;
 
     // Loop on points
-    for (std::size_t ip = 0; ip < nP; ip++){
+    for (int ip = 0; ip < nP; ip++){
 
         const std::array<double,3> & point = points[ip];
         const long & cellId = ids[ip];
@@ -764,15 +764,15 @@ void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, co
         if (shared){
 
             // If all points are shared between processes all reduce on normal by minimum operation
-            MPI_Allreduce(MPI_IN_PLACE, normals, 3*nP, MPI_DOUBLE, MPI_MIN, tree->getCommunicator());
+            MPI_Allreduce(MPI_IN_PLACE, normals, 3*nP, MPI_DOUBLE, MPI_MIN, tree->getPatch().getCommunicator());
 
         } else {
 
             // Send/receive number of normals to send to other processes
-            std::vector<std::size_t> n_send_to_rank(nProcessors, 0);
+            std::vector<int> n_send_to_rank(nProcessors, 0);
             for (int irank = 0; irank < nProcessors; irank++){
-                std::size_t n_ask_to_current_rank = ask_to_rank[irank].size();
-                MPI_Gather(&n_ask_to_current_rank, 1, MPI_LONG, n_send_to_rank.data(), 1, MPI_LONG, irank, tree->getCommunicator());
+                int n_ask_to_current_rank = ask_to_rank[irank].size();
+                MPI_Gather(&n_ask_to_current_rank, 1, MPI_INT, n_send_to_rank.data(), 1, MPI_INT, irank, tree->getPatch().getCommunicator());
             }
 
             // Map with rank to send info for cellId and point coordinates
@@ -788,23 +788,23 @@ void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, co
                 if (myrank == irank){
                     for (int jrank = 0; jrank < nProcessors; jrank++){
                         if (jrank != irank){
-                            std::size_t n_send_to_current_rank = n_send_to_rank[jrank];
-                            MPI_Recv(send_to_rank[jrank].data(), n_send_to_current_rank, MPI_LONG, jrank, 100, tree->getCommunicator(), MPI_STATUS_IGNORE);
-                            MPI_Recv(point_from_rank[jrank].data(), n_send_to_current_rank*3, MPI_DOUBLE, jrank, 101, tree->getCommunicator(), MPI_STATUS_IGNORE);
+                            int n_send_to_current_rank = n_send_to_rank[jrank];
+                            MPI_Recv(send_to_rank[jrank].data(), n_send_to_current_rank, MPI_LONG, jrank, 100, tree->getPatch().getCommunicator(), MPI_STATUS_IGNORE);
+                            MPI_Recv(point_from_rank[jrank].data(), n_send_to_current_rank*3, MPI_DOUBLE, jrank, 101, tree->getPatch().getCommunicator(), MPI_STATUS_IGNORE);
                         }
                     }
                 } else {
-                    std::size_t n_ask_to_current_rank = ask_to_rank[irank].size();
-                    MPI_Send(ask_to_rank[irank].data(), n_ask_to_current_rank, MPI_LONG, irank, 100, tree->getCommunicator());
-                    MPI_Send(point_to_rank[irank].data(), n_ask_to_current_rank*3, MPI_DOUBLE, irank, 101, tree->getCommunicator());
+                    int n_ask_to_current_rank = ask_to_rank[irank].size();
+                    MPI_Send(ask_to_rank[irank].data(), n_ask_to_current_rank, MPI_LONG, irank, 100, tree->getPatch().getCommunicator());
+                    MPI_Send(point_to_rank[irank].data(), n_ask_to_current_rank*3, MPI_DOUBLE, irank, 101, tree->getPatch().getCommunicator());
                 }
             }
 
             // Compute pseudo-normal for each received point from each rank
             std::map<int, std::vector<std::array<double,3>>> normal_to_rank;
-            for (std::size_t irank = 0; irank < nProcessors; irank++){
+            for (int irank = 0; irank < nProcessors; irank++){
                 normal_to_rank[irank].resize(n_send_to_rank[irank], std::array<double,3>({std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max()}));
-                for (std::size_t ip = 0; ip < n_send_to_rank[irank]; ip++){
+                for (int ip = 0; ip < n_send_to_rank[irank]; ip++){
 
                     const std::array<double,3> & point = point_from_rank[irank][ip];
                     const long & cellId = send_to_rank[irank][ip];
@@ -822,21 +822,21 @@ void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, co
                 if (myrank == irank){
                     for (int jrank = 0; jrank < nProcessors; jrank++){
                         if (jrank != irank){
-                            std::size_t n_ask_to_current_rank = ask_to_rank[jrank].size();
+                            int n_ask_to_current_rank = ask_to_rank[jrank].size();
                             normal_from_rank[jrank].resize(n_ask_to_current_rank);
-                            MPI_Recv(normal_from_rank[jrank].data(), n_ask_to_current_rank*3, MPI_DOUBLE, jrank, 102, tree->getCommunicator(), MPI_STATUS_IGNORE);
+                            MPI_Recv(normal_from_rank[jrank].data(), n_ask_to_current_rank*3, MPI_DOUBLE, jrank, 102, tree->getPatch().getCommunicator(), MPI_STATUS_IGNORE);
 
                             // Fill normals output with the correct received pseudonormals (TODO move out of communications scope?)
-                            for (std::size_t ip = 0; ip < n_ask_to_current_rank; ip++){
-                                std::size_t point_index = point_index_received_from_rank[jrank][ip];
+                            for (int ip = 0; ip < n_ask_to_current_rank; ip++){
+                                int point_index = point_index_received_from_rank[jrank][ip];
                                 normals[point_index] = normal_from_rank[jrank][ip];
                             }
 
                         }
                     }
                 } else {
-                    std::size_t n_send_to_current_rank = n_send_to_rank[irank];
-                    MPI_Send(normal_to_rank[irank].data(), n_send_to_current_rank*3, MPI_DOUBLE, irank, 102, tree->getCommunicator());
+                    int n_send_to_current_rank = n_send_to_rank[irank];
+                    MPI_Send(normal_to_rank[irank].data(), n_send_to_current_rank*3, MPI_DOUBLE, irank, 102, tree->getPatch().getCommunicator());
                 }
             }
 
@@ -856,7 +856,7 @@ void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, co
  * every element encountered inside the sphere).
  * \param[out] Coordinates of the projected points.
  */
-void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, int *ranks, double r, bool shared )
+void projectPointGlobal(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, int *ranks, double r, bool shared )
 {
     std::vector<double> rs(nP, r);
     projectPointGlobal(nP, points, tree, projected_points, ids, ranks, rs.data(), shared);
@@ -874,11 +874,11 @@ void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, cons
  * every element encountered inside the sphere).
  * \param[out] Coordinates of the projected points.
  */
-void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, int *ranks, double *r, bool shared )
+void projectPointGlobal(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, int *ranks, double *r, bool shared )
 {
 
     // Initialize ids and ranks
-    for (std::size_t ip = 0; ip < nP; ip++){
+    for (int ip = 0; ip < nP; ip++){
         ids[ip] = bitpit::Cell::NULL_ID;
         ranks[ip] = -1;
         r[ip] = std::max(r[ip], tree->getPatch().getTol());
@@ -890,7 +890,7 @@ void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, cons
     while (max_dist >= std::numeric_limits<double>::max()){
         //use method sphere by default
         signedGlobalDistance(nP, points, tree, ids, ranks, normals.data(), dist.data(), r, shared);
-        for (std::size_t ip = 0; ip < nP; ip++){
+        for (int ip = 0; ip < nP; ip++){
             if (std::abs(dist[ip]) >= max_dist){
                 r[ip] *= 1.5;
             }
@@ -899,7 +899,7 @@ void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, cons
         max_dist = std::max(max_dist, std::abs(*std::min_element(dist.begin(), dist.end())));
     }
 
-    for (std::size_t ip = 0; ip < nP; ip++){
+    for (int ip = 0; ip < nP; ip++){
         projected_points[ip] = points[ip] - dist[ip] * normals[ip];
     }
 }
@@ -914,7 +914,7 @@ void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, cons
  * \param[out] ranks Ranks of the process owner of the elements found as location of the points.
  * \param[in] shared True if the input points are shared between the processes
  */
-void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, bool shared)
+void locatePointOnGlobalPatch(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, bool shared)
 {
     if(!dynamic_cast<const bitpit::SurfUnstructured*>(&(tree->getPatch()))){
         throw std::runtime_error("Invalid use of skdTreeUtils::locatePointOnPatch method: a non surface patch or void patch was detected.");
@@ -922,7 +922,7 @@ void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points
     const bitpit::SurfUnstructured & spatch = static_cast<const bitpit::SurfUnstructured&>(tree->getPatch());
 
     // Initialize the cell id and distance
-    for (std::size_t ip = 0; ip < nP; ip++){
+    for (int ip = 0; ip < nP; ip++){
         ids[ip] = bitpit::Cell::NULL_ID;
     }
     std::vector<double> distances(nP, std::numeric_limits<double>::max());
@@ -943,10 +943,10 @@ void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points
     // Map with rank to ask info in case of distributed points
     std::map<int,std::vector<long>> ask_to_rank;
     std::map<int,std::vector<std::array<double,3>>> point_to_rank;
-    std::map<int,std::vector<std::size_t>> point_index_received_from_rank;
+    std::map<int,std::vector<int>> point_index_received_from_rank;
 
     // Loop on points
-    for (std::size_t ip = 0; ip < nP; ip++){
+    for (int ip = 0; ip < nP; ip++){
 
         const std::array<double,3> & point = points[ip];
         const long & cellId = cellIds[ip];
@@ -989,15 +989,15 @@ void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points
         if (shared){
 
             // If all points are shared between processes all reduce on ids by maximum operation
-            MPI_Allreduce(MPI_IN_PLACE, ids, nP, MPI_LONG, MPI_MAX, tree->getCommunicator());
+            MPI_Allreduce(MPI_IN_PLACE, ids, nP, MPI_LONG, MPI_MAX, tree->getPatch().getCommunicator());
 
         } else {
 
             // Send/receive number of check belong to send to other processes
-            std::vector<std::size_t> n_send_to_rank(nProcessors, 0);
+            std::vector<int> n_send_to_rank(nProcessors, 0);
             for (int irank = 0; irank < nProcessors; irank++){
-                std::size_t n_ask_to_current_rank = ask_to_rank[irank].size();
-                MPI_Gather(&n_ask_to_current_rank, 1, MPI_LONG, n_send_to_rank.data(), 1, MPI_LONG, irank, tree->getCommunicator());
+                int n_ask_to_current_rank = ask_to_rank[irank].size();
+                MPI_Gather(&n_ask_to_current_rank, 1, MPI_INT, n_send_to_rank.data(), 1, MPI_INT, irank, tree->getPatch().getCommunicator());
             }
 
             // Map with rank to send info for cellId and point coordinates
@@ -1013,23 +1013,23 @@ void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points
                 if (myrank == irank){
                     for (int jrank = 0; jrank < nProcessors; jrank++){
                         if (jrank != irank){
-                            std::size_t n_send_to_current_rank = n_send_to_rank[jrank];
-                            MPI_Recv(send_to_rank[jrank].data(), n_send_to_current_rank, MPI_LONG, jrank, 100, tree->getCommunicator(), MPI_STATUS_IGNORE);
-                            MPI_Recv(point_from_rank[jrank].data(), n_send_to_current_rank*3, MPI_DOUBLE, jrank, 101, tree->getCommunicator(), MPI_STATUS_IGNORE);
+                            int n_send_to_current_rank = n_send_to_rank[jrank];
+                            MPI_Recv(send_to_rank[jrank].data(), n_send_to_current_rank, MPI_LONG, jrank, 100, tree->getPatch().getCommunicator(), MPI_STATUS_IGNORE);
+                            MPI_Recv(point_from_rank[jrank].data(), n_send_to_current_rank*3, MPI_DOUBLE, jrank, 101, tree->getPatch().getCommunicator(), MPI_STATUS_IGNORE);
                         }
                     }
                 } else {
-                    std::size_t n_ask_to_current_rank = ask_to_rank[irank].size();
-                    MPI_Send(ask_to_rank[irank].data(), n_ask_to_current_rank, MPI_LONG, irank, 100, tree->getCommunicator());
-                    MPI_Send(point_to_rank[irank].data(), n_ask_to_current_rank*3, MPI_DOUBLE, irank, 101, tree->getCommunicator());
+                    int n_ask_to_current_rank = ask_to_rank[irank].size();
+                    MPI_Send(ask_to_rank[irank].data(), n_ask_to_current_rank, MPI_LONG, irank, 100, tree->getPatch().getCommunicator());
+                    MPI_Send(point_to_rank[irank].data(), n_ask_to_current_rank*3, MPI_DOUBLE, irank, 101, tree->getPatch().getCommunicator());
                 }
             }
 
             // Check if the point belong to cell for each received point from each rank
             std::map<int, std::vector<int>> checkBelong_to_rank;
-            for (std::size_t irank = 0; irank < nProcessors; irank++){
+            for (int irank = 0; irank < nProcessors; irank++){
                 checkBelong_to_rank[irank].resize(n_send_to_rank[irank], false);
-                for (std::size_t ip = 0; ip < n_send_to_rank[irank]; ip++){
+                for (int ip = 0; ip < n_send_to_rank[irank]; ip++){
 
                     const std::array<double,3> & point = point_from_rank[irank][ip];
                     const long & cellId = send_to_rank[irank][ip];
@@ -1047,13 +1047,13 @@ void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points
                 if (myrank == irank){
                     for (int jrank = 0; jrank < nProcessors; jrank++){
                         if (jrank != irank){
-                            std::size_t n_ask_to_current_rank = ask_to_rank[jrank].size();
+                            int n_ask_to_current_rank = ask_to_rank[jrank].size();
                             checkBelong_from_rank[jrank].resize(n_ask_to_current_rank);
-                            MPI_Recv(checkBelong_from_rank[jrank].data(), n_ask_to_current_rank, MPI_INT, jrank, 102, tree->getCommunicator(), MPI_STATUS_IGNORE);
+                            MPI_Recv(checkBelong_from_rank[jrank].data(), n_ask_to_current_rank, MPI_INT, jrank, 102, tree->getPatch().getCommunicator(), MPI_STATUS_IGNORE);
 
                             // Fill cell ids output if the received check belong is true (TODO move out of communications scope?)
-                            for (std::size_t ip = 0; ip < n_ask_to_current_rank; ip++){
-                                std::size_t point_index = point_index_received_from_rank[jrank][ip];
+                            for (int ip = 0; ip < n_ask_to_current_rank; ip++){
+                                int point_index = point_index_received_from_rank[jrank][ip];
                                 long cellId = ask_to_rank[jrank][ip];
                                 // Check received int value (zero or one) casting to boolean
                                 if (bool(checkBelong_from_rank[jrank][ip])) {
@@ -1064,8 +1064,8 @@ void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points
                         }
                     }
                 } else {
-                    std::size_t n_send_to_current_rank = n_send_to_rank[irank];
-                    MPI_Send(checkBelong_to_rank[irank].data(), n_send_to_current_rank, MPI_INT, irank, 102, tree->getCommunicator());
+                    int n_send_to_current_rank = n_send_to_rank[irank];
+                    MPI_Send(checkBelong_to_rank[irank].data(), n_send_to_current_rank, MPI_INT, irank, 102, tree->getPatch().getCommunicator());
                 }
             }
 
@@ -1086,7 +1086,7 @@ void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points
  */
 std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol){
 
-    if (!selection->isCommunicatorSet() || !target->isCommunicatorSet()){
+    if (!selection->getPatch().isCommunicatorSet() || !target->getPatch().isCommunicatorSet()){
         throw std::runtime_error("Error: at least one PatchSkdTree communicator not set in selectByGlobalPatch");
     }
     if (!selection->getPatch().isPartitioned() && !target->getPatch().isPartitioned()){
@@ -1096,8 +1096,8 @@ std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::P
     // Leaf selection nodes of current rank initialized for each rank of target bounding box
     int nprocs = selection->getPatch().getProcessorCount();
     int myRank = selection->getPatch().getRank();
-    std::size_t nleafs = selection->getLeafCount();
-    std::size_t nnodess = selection->getNodeCount();
+    int nleafs = selection->getLeafCount();
+    int nnodess = selection->getNodeCount();
     std::unordered_map<int, std::vector<const bitpit::SkdNode*>> rankLeafSelection;
     for (int irank = 0; irank < nprocs; irank++){
         std::vector<const bitpit::SkdNode*> leafSelection(nleafs);
@@ -1106,8 +1106,8 @@ std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::P
             if (selection->getNode(i).isLeaf()){
                 if (bitpit::CGElem::intersectBoxBox(selection->getNode(i).getBoxMin()-tol,
                         selection->getNode(i).getBoxMax()+tol,
-                        target->getPartitionBoxMin(irank),
-                        target->getPartitionBoxMax(irank) ) ){
+                        target->getPartitionBox(irank).getBoxMin(),
+                        target->getPartitionBox(irank).getBoxMax() ) ){
                     leafSelection[count] = &(selection->getNode(i));
                     count++;
                 }
@@ -1132,7 +1132,7 @@ std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::P
     for (int irank = 0; irank < nprocs; irank++){
         // Scatter send to all process of irank process data
         int * recvbuff = &nLeafRecv[irank];
-        MPI_Scatter(nLeafSend.data(), 1, MPI_INT, recvbuff, 1, MPI_INT, irank, selection->getCommunicator());
+        MPI_Scatter(nLeafSend.data(), 1, MPI_INT, recvbuff, 1, MPI_INT, irank, selection->getPatch().getCommunicator());
     }
 
     // Recover global leaf received to resize local received boxes container
@@ -1179,13 +1179,13 @@ std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::P
         }
 
         // Gather bounding boxes points to the root process
-        MPI_Gatherv(sendBoxes.data(), nSendData, MPI_DOUBLE, recvBoxes.data(), nRecvDataPerProc.data(), recvDispls.data(), MPI_DOUBLE, irank, selection->getCommunicator());
+        MPI_Gatherv(sendBoxes.data(), nSendData, MPI_DOUBLE, recvBoxes.data(), nRecvDataPerProc.data(), recvDispls.data(), MPI_DOUBLE, irank, selection->getPatch().getCommunicator());
 
     } // End loop on root processes
 
     // Fill leaf selection boxes container
     std::vector<double>::iterator itBox = recvBoxes.begin();
-    for (std::size_t ibox = 0; ibox < nGlobalReceived; ibox++){
+    for (int ibox = 0; ibox < nGlobalReceived; ibox++){
         std::array<double, 3> minPoint;
         minPoint[0] = *(itBox++);
         minPoint[1] = *(itBox++);
@@ -1222,16 +1222,16 @@ void extractTarget(bitpit::PatchSkdTree *target, const std::vector<bitpit::SkdBo
 {
 
     if(leafSelectionBoxes.empty()) return;
-    std::size_t rootId = 0;
+    long rootId = 0;
 
     // Candidates saved in set to avoid duplicate
-    std::unordered_set<std::size_t> candidates;
+    std::unordered_set<long> candidates;
 
     // Loop on leaf selection boxes and go across the target tree with a node stack
     for (const bitpit::SkdBox & selectionBox : leafSelectionBoxes){
 
         // Initialize stack with target root node
-        std::queue<std::size_t> nodeStack;
+        std::queue<long> nodeStack;
         nodeStack.push(rootId);
 
         // Pop and push target tree nodes checked with current selection boxe
@@ -1239,14 +1239,14 @@ void extractTarget(bitpit::PatchSkdTree *target, const std::vector<bitpit::SkdBo
         // Stop when stack is empty
         while(!nodeStack.empty()){
 
-            std::size_t nodeId = nodeStack.front();
+            long nodeId = nodeStack.front();
             nodeStack.pop();
             const bitpit::SkdNode & node = target->getNode(nodeId);
 
             bool isLeaf = true;
             for (int i = bitpit::SkdNode::CHILD_BEGIN; i != bitpit::SkdNode::CHILD_END; ++i) {
                 bitpit::SkdNode::ChildLocation childLocation = static_cast<bitpit::SkdNode::ChildLocation>(i);
-                std::size_t childId = node.getChildId(childLocation);
+                long childId = node.getChildId(childLocation);
                 if (childId != bitpit::SkdNode::NULL_ID) {
                     isLeaf = false;
                     if (bitpit::CGElem::intersectBoxBox(selectionBox.getBoxMin()-tol, selectionBox.getBoxMax()+tol,
@@ -1264,7 +1264,7 @@ void extractTarget(bitpit::PatchSkdTree *target, const std::vector<bitpit::SkdBo
     // Extract cell from candidates nodes
     // Do not check for intersection -> exctraction performed only by using bounding boxes of leaf nodes of the skd-trees
     std::unordered_set<long> cellExtracted;
-    for(std::size_t nodeId : candidates){
+    for(long nodeId : candidates){
         const bitpit::SkdNode & node = target->getNode(nodeId);
         std::vector<long> cellids = node.getCells();
         cellExtracted.insert(cellids.begin(), cellids.end());
@@ -1294,11 +1294,11 @@ void extractTarget(bitpit::PatchSkdTree *target, const std::vector<bitpit::SkdBo
 * farther than the maximum distance, the related argument will be set to the
 * maximum representable distance.
 */
-void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<double, 3> *points, const bitpit::PatchSkdTree *tree,
+long findSharedPointClosestGlobalCell(int nPoints, const std::array<double, 3> *points, const bitpit::PatchSkdTree *tree,
         long *ids, int *ranks, double *distances, double r)
 {
     std::vector<double> rs(nPoints, r);
-    findSharedPointClosestGlobalCell(nPoints, points, tree, ids, ranks, distances, rs.data());
+    return findSharedPointClosestGlobalCell(nPoints, points, tree, ids, ranks, distances, rs.data());
 }
 
 /*!
@@ -1321,85 +1321,89 @@ void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<doub
 * farther than the maximum distance, the related argument will be set to the
 * maximum representable distance.
 */
-void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<double, 3> *points, const bitpit::PatchSkdTree *tree,
+long findSharedPointClosestGlobalCell(int nPoints, const std::array<double, 3> *points, const bitpit::PatchSkdTree *tree,
         long *ids, int *ranks, double *distances, double *r)
 {
-    // Initialize the cell ids and ranks
-    for (std::size_t i = 0; i < nPoints; i++){
-        ids[i] = bitpit::Cell::NULL_ID;
-        ranks[i] = -1;
+
+    long nDistanceEvaluations = 0;
+
+    std::vector<double> maxDistances(nPoints, std::numeric_limits<double>::max());
+
+    // Early return is the patch is not partitioned
+    const bitpit::PatchKernel &patch = tree->getPatch();
+    if (!patch.isPartitioned()) {
+        for (int i = 0; i < nPoints; ++i) {
+            // Evaluate distance
+            nDistanceEvaluations += findPointClosestCell(points[i], tree, maxDistances[i], ids + i, distances + i);
+
+            // The patch is not partitioned, all cells are local
+            ranks[i] = patch.getRank();
+
+            return nDistanceEvaluations;
+        }
     }
 
-    // Initialize rank and number of processes
+    // Get MPI communicator
+    // Patch is partitioned call the parallel method
+    if (!tree->getPatch().isCommunicatorSet()){
+        throw std::runtime_error ("There is no communicator set for the patch.");
+    }
+
+    MPI_Comm communicator = tree->getPatch().getCommunicator();
+    int nprocs = tree->getPatch().getProcessorCount();
     int myRank = tree->getPatch().getRank();
-    int nProcs = tree->getPatch().getProcessorCount();
 
-    // Call local find point closest cell for each global point collected
+    // Initialize distance information
+    std::vector<bitpit::SkdGlobalCellDistance> globalCellDistances(nPoints);
 
-    // Instantiate global container for distances, ids and ranks (SkdCellInfo)
-    std::vector<bitpit::PatchSkdTree::SkdCellInfo> dri_data(nPoints, bitpit::PatchSkdTree::SkdCellInfo(std::numeric_limits<double>::max(), myRank, bitpit::Cell::NULL_ID));
+    // Call local find point closest cell for each point
+    for (int i = 0; i < nPoints; ++i) {
+        // Get point information
+        const std::array<double, 3> &point = points[i];
 
-    // Call local find point closest cell for each global point collected
-    for (std::size_t ip = 0; ip < nPoints; ip++){
-
-        const std::array<double,3> & point = points[ip];
-        double & distance = dri_data[ip].distance;
-        int & rank = dri_data[ip].rank;
-        long & id = dri_data[ip].id;
-
-        // Use a maximum distance for each point given by an estimation based on partition
-        // bounding boxes. The distance will be lesser than or equal to the point maximum distance
-        double pointMaxDistance = r[ip];
-        for (int irank = 0; irank < nProcs; irank++){
-            pointMaxDistance = std::min(tree->getPartitionBox(irank).evalPointMaxDistance(point), pointMaxDistance);
+        // Use a maximum distance for each point given by an estimation
+        // based on partition bounding boxes. The distance will be lesser
+        // than or equal to the point maximum distance.
+        double pointMaxDistance = maxDistances[i];
+        for (int rank = 0; rank < nprocs; ++rank) {
+            pointMaxDistance = std::min(tree->getPartitionBox(rank).evalPointMaxDistance(point), pointMaxDistance);
         }
 
-        // Call local find point closest cell with estimated distance used as maximum distance
-        long nDistanceEvaluations = tree->findPointClosestCell(point, pointMaxDistance, &id, &distance);
+        // Get cell distance information
+        bitpit::SkdGlobalCellDistance &globalCellDistance = globalCellDistances[i];
+        int &cellRank = globalCellDistance.getRank();
+        long &cellId = globalCellDistance.getId();
+        double &cellDistance = globalCellDistance.getDistance();
 
-    }
+        // Evaluate local distance from the point
+        bool interiorOnly = true;
+        nDistanceEvaluations += findPointClosestCell(point, tree, pointMaxDistance, interiorOnly, &cellId, &cellDistance);
 
-    // Force distance to numeric limits maximum value for point projected on ghost cells
-    // The desired result id is the local cell id on the ghost owner rank
-    for (std::size_t ip = 0; ip < nPoints; ip++){
-        long cellId = dri_data[ip].id;
-        if(cellId != bitpit::Cell::NULL_ID && !tree->getPatch().getCell(cellId).isInterior()) {
-            dri_data[ip].id = tree->getGhostCellsRemoteIds().at(cellId);
-            dri_data[ip].rank = tree->getPatch().getCellRank(cellId);
+        // Set cell rank
+        if (cellId != bitpit::Cell::NULL_ID) {
+            cellRank = patch.getCellRank(cellId);
         }
     }
 
-    // Communicate the computed distances of the distributed input points to all processes
-    // and retain the indices of the rank owner and the id of the closest cell
-
-    // Prepare MPI custom data type and Operation
-    // The data are of MPI custom data type  with distance, ids and rank as member
-    int blocklengths[3] = {1,1,1};
-    MPI_Aint displacements[3] = {offsetof(bitpit::PatchSkdTree::SkdCellInfo, distance),
-            offsetof(bitpit::PatchSkdTree::SkdCellInfo, rank),
-            offsetof(bitpit::PatchSkdTree::SkdCellInfo, id)};
-    MPI_Datatype types[3] = {MPI_DOUBLE, MPI_INT, MPI_LONG};
-    MPI_Datatype MPI_DRI;
-    MPI_Type_create_struct(3, blocklengths, displacements, types, &MPI_DRI);
-    MPI_Type_commit(&MPI_DRI);
-
-    MPI_Op MPI_MIN_DRI;
-    MPI_Op_create((MPI_User_function *) bitpit::minSkdCellInfo, false, &MPI_MIN_DRI);
-
+    // Exchange distance information
     // Communicate the closest cells distances, ranks and ids by reduce with custom minimum distance operation
     // Reduce only the right portion of data to the right process
-    for (int irank = 0; irank < nProcs; irank++){
-        MPI_Allreduce(MPI_IN_PLACE, dri_data.data(), nPoints, MPI_DRI, MPI_MIN_DRI, tree->getCommunicator());
+    MPI_Datatype globalCellDistanceDatatype = bitpit::SkdGlobalCellDistance::getMPIDatatype();
+    MPI_Op globalCellDistanceMinOp = bitpit::SkdGlobalCellDistance::getMPIMinOperation();
+    bitpit::SkdGlobalCellDistance *globalCellDistance = globalCellDistances.data();
+    for (int irank = 0; irank < nprocs; irank++){
+        MPI_Allreduce(MPI_IN_PLACE, globalCellDistance, nPoints, globalCellDistanceDatatype, globalCellDistanceMinOp, tree->getPatch().getCommunicator());
     }
 
-    // Update distances, rank indices and cell ids
-    for (std::size_t ip = 0; ip < nPoints; ip++){
-        distances[ip] = dri_data[ip].distance;
-        ranks[ip] = dri_data[ip].rank;
-        ids[ip] = dri_data[ip].id;
+    // Update output arguments
+    for (int i = 0; i < nPoints; ++i) {
+        int globalIndex = i;
+        bitpit::SkdGlobalCellDistance &globalCellDistance = globalCellDistances[globalIndex];
+        globalCellDistance.exportData(ranks + i, ids + i, distances + i);
     }
+
+    return nDistanceEvaluations;
 }
-
 #endif
 
 /*!
@@ -1408,6 +1412,9 @@ void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<doub
 * point.
 * \param[in] point is the point
 * \param[in] tree pointer to SkdTree relative to the target volume geometry.
+* \param[in] interiorOnly if set to true, only interior cells will be considered,
+* it will be possible to consider non-interior cells only if the tree has been
+* instantiated with non-interior cells support enabled
 * \param[out] id on output it will contain the id of the cell closest
 * to the point, if the distance between the point and the surface is
 * greater than the specified maximum distance, the id parameter will
@@ -1417,11 +1424,12 @@ void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<doub
 * tree are farther than the maximum distance, the function will return
 * the maximum representable distance.
 */
-long findPointClosestCell(const std::array<double, 3> &point, const bitpit::VolumeSkdTree *tree, long *id, double *distance)
+long findPointClosestCell(const std::array<double, 3> &point, const bitpit::PatchSkdTree *tree, bool interiorOnly, long *id, double *distance)
 {
-    return findPointClosestCell(point, tree, std::numeric_limits<double>::max(), id, distance);
+    return findPointClosestCell(point, tree, std::numeric_limits<double>::max(), interiorOnly, id, distance);
 
 }
+
 /*!
 * Given the specified point find the closest cell contained in a
 * skd-tree and evaluates the distance between that cell and the given
@@ -1431,6 +1439,9 @@ long findPointClosestCell(const std::array<double, 3> &point, const bitpit::Volu
 * \param[in] maxDistance all cells whose distance is greater than
 * this parameters will not be considered for the evaluation of the
 * distance
+* \param[in] interiorOnly if set to true, only interior cells will be considered,
+* it will be possible to consider non-interior cells only if the tree has been
+* instantiated with non-interior cells support enabled
 * \param[out] id on output it will contain the id of the closest cell.
 * If all cells contained in the tree are farther than the maximum
 * distance, the argument will be set to the null id
@@ -1439,8 +1450,8 @@ long findPointClosestCell(const std::array<double, 3> &point, const bitpit::Volu
 * farther than the maximum distance, the argument will be set to the
 * maximum representable distance
 */
-long findPointClosestCell(const std::array<double, 3> &point, const bitpit::VolumeSkdTree *tree,
-        double maxDistance, long *id, double *distance)
+long findPointClosestCell(const std::array<double, 3> &point, const bitpit::PatchSkdTree *tree,
+        double maxDistance, bool interiorOnly, long *id, double *distance)
 {
 
     // Initialize the cell id
@@ -1449,20 +1460,20 @@ long findPointClosestCell(const std::array<double, 3> &point, const bitpit::Volu
     // Initialize the distance with an estimate
     //
     // The real distance will be lesser than or equal to the estimate.
-    std::size_t rootId = 0;
+    long rootId = 0;
     const bitpit::SkdNode &root = tree->getNode(rootId);
     *distance = std::min(root.evalPointMaxDistance(point), maxDistance);
 
     // Get a list of candidates nodes
     //
     // Initialize list of candidates
-    std::vector<std::size_t> candidateIds;
+    std::vector<long> candidateIds;
     std::vector<double> candidateMinDistances;
 
-    std::vector<std::size_t> nodeStack;
+    std::vector<long> nodeStack;
     nodeStack.push_back(rootId);
     while (!nodeStack.empty()) {
-        std::size_t nodeId = nodeStack.back();
+        long nodeId = nodeStack.back();
         const bitpit::SkdNode &node = tree->getNode(nodeId);
         nodeStack.pop_back();
 
@@ -1485,7 +1496,7 @@ long findPointClosestCell(const std::array<double, 3> &point, const bitpit::Volu
         bool isLeaf = true;
         for (int i = bitpit::SkdNode::CHILD_BEGIN; i != bitpit::SkdNode::CHILD_END; ++i) {
             bitpit::SkdNode::ChildLocation childLocation = static_cast<bitpit::SkdNode::ChildLocation>(i);
-            std::size_t childId = node.getChildId(childLocation);
+            long childId = node.getChildId(childLocation);
             if (childId != bitpit::SkdNode::NULL_ID) {
                 isLeaf = false;
                 nodeStack.push_back(childId);
@@ -1500,7 +1511,7 @@ long findPointClosestCell(const std::array<double, 3> &point, const bitpit::Volu
 
     // Process the candidates and find the closest cell
     long nDistanceEvaluations = 0;
-    for (std::size_t k = 0; k < candidateIds.size(); ++k) {
+    for (int k = 0; k < candidateIds.size(); ++k) {
         // Do not consider nodes with a minimum distance greater than
         // the distance estimate
         if (candidateMinDistances[k] > *distance) {
@@ -1508,10 +1519,10 @@ long findPointClosestCell(const std::array<double, 3> &point, const bitpit::Volu
         }
 
         // Evaluate the distance
-        std::size_t nodeId = candidateIds[k];
+        long nodeId = candidateIds[k];
         const bitpit::SkdNode &node = tree->getNode(nodeId);
 
-        node.updatePointClosestCell(point, id, distance);
+        node.updatePointClosestCell(point, interiorOnly, id, distance);
         ++nDistanceEvaluations;
     }
 
@@ -1539,130 +1550,119 @@ long findPointClosestCell(const std::array<double, 3> &point, const bitpit::Volu
 * \param[out] distances on output it will contain the distances
 * between the points and closest cells
 */
-void findPointClosestGlobalCell(const std::size_t nPoints, const std::array<double, 3> *points,
-        const bitpit::VolumeSkdTree *tree, long *ids, int *ranks, double *distances)
+long findPointClosestGlobalCell(int nPoints, const std::array<double, 3> *points,
+        const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances)
 {
+
+    long nDistanceEvaluations = 0;
+
     std::vector<double> maxDistances(nPoints, std::numeric_limits<double>::max());
 
+    // Early return is the patch is not partitioned
+    const bitpit::PatchKernel &patch = tree->getPatch();
+    if (!patch.isPartitioned()) {
+        for (int i = 0; i < nPoints; ++i) {
+            // Evaluate distance
+            nDistanceEvaluations += findPointClosestCell(points[i], tree, maxDistances[i], ids + i, distances + i);
+
+            // The patch is not partitioned, all cells are local
+            ranks[i] = patch.getRank();
+
+            return nDistanceEvaluations;
+        }
+    }
+
+    // Get MPI communicator
     // Patch is partitioned call the parallel method
     if (!tree->getPatch().isCommunicatorSet()){
         throw std::runtime_error ("There is no communicator set for the patch.");
     }
 
+    MPI_Comm communicator = tree->getPatch().getCommunicator();
     int nprocs = tree->getPatch().getProcessorCount();
     int myRank = tree->getPatch().getRank();
 
-    // Initialize the cell ids and ranks
-    for (std::size_t i = 0; i < nPoints; i++){
-        ids[i] = bitpit::Cell::NULL_ID;
-        ranks[i] = -1;
-    }
-
-    // Communicate all the points to all the processes
-    // Gather number of points multiplied by number of coordinates,
-    // i.e. number of data to communicate
+    // Gather the number of points associated to each process
     std::vector<int> pointsCount(nprocs);
-    MPI_Allgather(&nPoints, 1, MPI_INT, pointsCount.data(), 1, MPI_INT, tree->getCommunicator());
+    MPI_Allgather(&nPoints, 1, MPI_INT, pointsCount.data(), 1, MPI_INT, communicator);
 
-    // Recover points displacements, offset and number of points data per process
-    std::vector<int> pointsDispls(nprocs, 0);
-    std::vector<int> pointsOffsets(nprocs, 0);
-    std::vector<int> pointsCountData(nprocs, 0);
-    pointsCountData[0] = pointsCount[0] * 3;
+    // Evaluate information for data communications
+    std::vector<int> globalPointsDispls(nprocs, 0);
+    std::vector<int> globalPointsOffsets(nprocs, 0);
+    std::vector<int> globalPointsDataCount(nprocs, 0);
+
+    globalPointsDataCount[0] = 3 * pointsCount[0];
     for (int i = 1; i < nprocs; ++i) {
-        pointsDispls[i] = pointsDispls[i - 1] + pointsCount[i - 1] * 3;
-        pointsOffsets[i] = pointsOffsets[i - 1] + pointsCount[i - 1];
-        pointsCountData[i] = pointsCount[i] * 3;
+        globalPointsDispls[i]     = globalPointsDispls[i - 1] + 3 * pointsCount[i - 1];
+        globalPointsOffsets[i]    = globalPointsOffsets[i - 1] + pointsCount[i - 1];
+        globalPointsDataCount[i]  = 3 * pointsCount[i];
     }
 
-    // Sum to global number of points
-    int nGlobalPoints = 0;
-    for (int np : pointsCount){
-        nGlobalPoints += np;
-    }
+    int nGlobalPoints = globalPointsDispls.back() + pointsCount.back();
 
-    // Gather vector with all global points
+    // Gather point coordinates
     std::vector<std::array<double,3>> globalPoints(nGlobalPoints);
-    std::size_t nPointsCountData = nPoints * 3;
-    MPI_Allgatherv(points, nPointsCountData, MPI_DOUBLE, globalPoints.data(),
-            pointsCountData.data(), pointsDispls.data(), MPI_DOUBLE, tree->getCommunicator());
+    int pointsDataCount = 3 * nPoints;
+    MPI_Allgatherv(points, pointsDataCount, MPI_DOUBLE, globalPoints.data(),
+            globalPointsDataCount.data(), globalPointsDispls.data(), MPI_DOUBLE, communicator);
 
     // Gather vector with all maximum distances
     std::vector<double> globalMaxDistances(nGlobalPoints);
     MPI_Allgatherv(maxDistances.data(), nPoints, MPI_DOUBLE, globalMaxDistances.data(),
-            pointsCount.data(), pointsOffsets.data(), MPI_DOUBLE, tree->getCommunicator());
+            pointsCount.data(), globalPointsOffsets.data(), MPI_DOUBLE, communicator);
+
+    // Initialize distance information
+    std::vector<bitpit::SkdGlobalCellDistance> globalCellDistances(nGlobalPoints);
 
     // Call local find point closest cell for each global point collected
+    for (int i = 0; i < nGlobalPoints; ++i) {
+        // Get point information
+        const std::array<double, 3> &point = globalPoints[i];
 
-    // Instantiate global container for distances, ids and ranks (SkdCellInfo)
-    std::vector<bitpit::PatchSkdTree::SkdCellInfo> dri_data(nGlobalPoints, bitpit::PatchSkdTree::SkdCellInfo(std::numeric_limits<double>::max(), myRank, bitpit::Cell::NULL_ID));
-
-    // Call local find point closest cell for each global point collected
-    for (std::size_t ip = 0; ip < nGlobalPoints; ip++){
-
-        const std::array<double,3> & point = globalPoints[ip];
-        double & distance = dri_data[ip].distance;
-        int & rank = dri_data[ip].rank;
-        long & id = dri_data[ip].id;
-
-        // Use a maximum distance for each point given by an estimation based on partition
-        // bounding boxes. The distance will be lesser than or equal to the point maximum distance
-        double pointMaxDistance = globalMaxDistances[ip];
-        for (int irank = 0; irank < nprocs; irank++){
-            pointMaxDistance = std::min(tree->getPartitionBox(irank).evalPointMaxDistance(point), pointMaxDistance);
+        // Use a maximum distance for each point given by an estimation
+        // based on partition bounding boxes. The distance will be lesser
+        // than or equal to the point maximum distance.
+        double pointMaxDistance = globalMaxDistances[i];
+        for (int rank = 0; rank < nprocs; ++rank) {
+            pointMaxDistance = std::min(tree->getPartitionBox(rank).evalPointMaxDistance(point), pointMaxDistance);
         }
 
-        // Call local find point closest cell with estimated distance used as maximum distance
-        long nDistanceEvaluations = findPointClosestCell(point, tree, pointMaxDistance, &id, &distance);
+        // Get cell distance information
+        bitpit::SkdGlobalCellDistance &globalCellDistance = globalCellDistances[i];
+        int &cellRank = globalCellDistance.getRank();
+        long &cellId = globalCellDistance.getId();
+        double &cellDistance = globalCellDistance.getDistance();
 
-    }
+        // Evaluate local distance from the point
+        bool interiorOnly = true;
+        nDistanceEvaluations += findPointClosestCell(point, tree, pointMaxDistance, interiorOnly, &cellId, &cellDistance);
 
-    // Force distance to numeric limits maximum value for point projected on ghost cells
-    // The desired result id is the local cell id on the ghost owner rank
-    for (std::size_t ip = 0; ip < nGlobalPoints; ip++){
-        long cellId = dri_data[ip].id;
-        if(cellId != bitpit::Cell::NULL_ID && !tree->getPatch().getCell(cellId).isInterior()) {
-            dri_data[ip].id = tree->getGhostCellsRemoteIds().at(cellId);
-            dri_data[ip].rank = tree->getPatch().getCellRank(cellId);
+        // Set cell rank
+        if (cellId != bitpit::Cell::NULL_ID) {
+            cellRank = patch.getCellRank(cellId);
         }
     }
 
-    // Communicate the computed distances of the distributed input points to all processes
-    // and retain the indices of the rank owner and the id of the closest cell
-
-    // Prepare MPI custom data type and Operation
-    // The data are of MPI custom data type  with distance, ids and rank as member
-    int blocklengths[3] = {1,1,1};
-    MPI_Aint displacements[3] = {offsetof(bitpit::PatchSkdTree::SkdCellInfo, distance),
-            offsetof(bitpit::PatchSkdTree::SkdCellInfo, rank),
-            offsetof(bitpit::PatchSkdTree::SkdCellInfo, id)};
-    MPI_Datatype types[3] = {MPI_DOUBLE, MPI_INT, MPI_LONG};
-    MPI_Datatype MPI_DRI;
-    MPI_Type_create_struct(3, blocklengths, displacements, types, &MPI_DRI);
-    MPI_Type_commit(&MPI_DRI);
-
-    MPI_Op MPI_MIN_DRI;
-    MPI_Op_create((MPI_User_function *) bitpit::minSkdCellInfo, false, &MPI_MIN_DRI);
-
-    // Communicate the closest cells distances, ranks and ids by reduce with custom minimum distance operation
-    // Reduce only the right portion of data to the right process
-    for (int irank = 0; irank < nprocs; irank++){
-        bitpit::PatchSkdTree::SkdCellInfo *buffer = (dri_data.data() + pointsOffsets[irank]);
-        if (myRank == irank){
-            MPI_Reduce(MPI_IN_PLACE, buffer, pointsCount[irank], MPI_DRI, MPI_MIN_DRI, irank, tree->getCommunicator());
+    // Exchange distance information
+    MPI_Datatype globalCellDistanceDatatype = bitpit::SkdGlobalCellDistance::getMPIDatatype();
+    MPI_Op globalCellDistanceMinOp = bitpit::SkdGlobalCellDistance::getMPIMinOperation();
+    for (int rank = 0; rank < nprocs; ++rank) {
+        bitpit::SkdGlobalCellDistance *globalCellDistance = globalCellDistances.data() + globalPointsOffsets[rank];
+        if (myRank == rank) {
+            MPI_Reduce(MPI_IN_PLACE, globalCellDistance, pointsCount[rank], globalCellDistanceDatatype, globalCellDistanceMinOp, rank, communicator);
         } else {
-            MPI_Reduce(buffer, buffer, pointsCount[irank], MPI_DRI, MPI_MIN_DRI, irank, tree->getCommunicator());
+            MPI_Reduce(globalCellDistance, globalCellDistance, pointsCount[rank], globalCellDistanceDatatype, globalCellDistanceMinOp, rank, communicator);
         }
     }
 
-    // Update distances, rank indices and cell ids
-    for (std::size_t ip = 0; ip < nPoints; ip++){
-        std::size_t globalIndex = ip + pointsOffsets[myRank];
-        distances[ip] = dri_data[globalIndex].distance;
-        ranks[ip] = dri_data[globalIndex].rank;
-        ids[ip] = dri_data[globalIndex].id;
+    // Update output arguments
+    for (int i = 0; i < nPoints; ++i) {
+        int globalIndex = i + globalPointsOffsets[myRank];
+        bitpit::SkdGlobalCellDistance &globalCellDistance = globalCellDistances[globalIndex];
+        globalCellDistance.exportData(ranks + i, ids + i, distances + i);
     }
 
+    return nDistanceEvaluations;
 }
 #endif
 }

--- a/src/core/SkdTreeUtils.cpp
+++ b/src/core/SkdTreeUtils.cpp
@@ -744,10 +744,11 @@ void signedGlobalDistance(int nP, const std::array<double,3> *points, const bitp
 
             double s = computePseudoNormal(point, &spatch, cellId, pseudo_normal);
             if(cellId != bitpit::Cell::NULL_ID){
-                distance *= s;
-            }
-            if (shared) {
-                signs[ip] = s;
+                if (shared) {
+                    signs[ip] = s;
+                }else{
+                    distance *= s;
+                }
             }
 
         } else {

--- a/src/core/SkdTreeUtils.cpp
+++ b/src/core/SkdTreeUtils.cpp
@@ -38,13 +38,13 @@ namespace skdTreeUtils{
  * object. The geometry has to be a surface mesh, in particular an object of type
  * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
  * It searches the element with minimum distance in a box of length 2*r, if none
- * is found return a default value of distance equal to std::numeric_limits<double>::max();
+ * is found return a default value of distance equal to std::numeric_limits<double>::max().
  * \param[in] point Pointer to coordinates of input point.
  * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
- * \param[out] id Label of the element found as minimum distance element in the bv-tree.
+ * \param[out] id Label of the element found as minimum distance element in the skd-tree.
  * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
  * every element encountered inside the box/sphere).
- * \return Unsigned distance of the input point from the patch in the bv-tree.
+ * \return Unsigned distance of the input point from the patch in the skd-tree.
  */
 double distance(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long &id, double r)
 {
@@ -70,16 +70,16 @@ double distance(const std::array<double,3> *point, const bitpit::PatchSkdTree *t
  * computed. A positive distance means that the point is located, in respect to the
  * surface mesh, on the same side of the outer normal vector.
  * It searches the element with minimum distance in a box of length 2*r, if none
- * is found return a default value of distance equal to std::numeric_limits<double>::max();
+ * is found return a default value of distance equal to std::numeric_limits<double>::max().
  * \param[in] point Pointer to coordinates of input point.
  * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
- * \param[out] id Label of the element found as minimum distance element in the bv-tree.
+ * \param[out] id Label of the element found as minimum distance element in the skd-tree.
  * \param[out] normal Pseudo-normal of the element (i.e. unit vector with direction (P-xP),
  * where P is the input point and xP the nearest point on the element (simplex) to
  * the projection of P on the plane of the simplex.
  * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
  * every element encountered inside the box/sphere).
- * \return Signed distance of the input point from the patch in the bv-tree.
+ * \return Signed distance of the input point from the patch in the skd-tree.
  */
 double signedDistance(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long &id, std::array<double,3> &normal, double r)
 {
@@ -107,12 +107,13 @@ double signedDistance(const std::array<double,3> *point, const bitpit::PatchSkdT
  * object. The geometry has to be a surface mesh, in particular an object of type
  * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
  * It searches the element with minimum distance in a box of length 2*r, if none
- * is found return a default value of distance equal to std::numeric_limits<double>::max();
+ * is found return a default value of distance equal to std::numeric_limits<double>::max() in the
+ * position of the distances array related to the input point.
  * \param[in] nP Number of input points.
  * \param[in] points Pointer to coordinates of input points.
  * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
- * \param[out] distances Unsigned distance of the input points from the patch in the bv-tree.
- * \param[out] ids Label of the elements found as minimum distance elements in the bv-tree.
+ * \param[out] distances Unsigned distance of the input points from the patch in the skd-tree.
+ * \param[out] ids Label of the elements found as minimum distance elements in the skd-tree.
  * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
  * every element encountered inside the box/sphere).
  */
@@ -148,12 +149,13 @@ void distance(size_t nP, const std::array<double,3> *points, const bitpit::Patch
  * computed. A positive distance means that the point is located, in respect to the
  * surface mesh, on the same side of the outer normal vector.
  * It searches the element with minimum distance in a box of length 2*r, if none
- * is found return a default value of distance equal to std::numeric_limits<double>::max();
+ * is found return a default value of distance equal to std::numeric_limits<double>::max() in the
+ * position of the distances array related to the input point.
  * \param[in] nP Number of input points.
  * \param[in] points Pointer to coordinates of input points.
  * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
- * \param[out] distances Signed distance of the input points from the patch in the bv-tree.
- * \param[out] ids Label of the elements found as minimum distance elements in the bv-tree.
+ * \param[out] distances Signed distance of the input points from the patch in the skd-tree.
+ * \param[out] ids Label of the elements found as minimum distance elements in the skd-tree.
  * \param[out] normals Pseudo-normal of the elements (i.e. unit vector with direction (P-xP),
  * where P is the input point and xP the nearest point on the element (simplex) to
  * the projection of P on the plane of the simplex.
@@ -187,13 +189,13 @@ double signedDistance(std::size_t nP, const std::array<double,3> *points, const 
 }
 
 /*!
- * It selects the elements of a geometry stored in a skdtree by a distance criterion
- * in respect to an other geometry stored in a different skdtree.
- * \param[in] selection Pointer to bv-tree used as selection patch.
- * \param[in] target Pointer to bv-tree that store the target geometry.
+ * It selects the elements of a geometry stored in a skd-tree by a distance criterion
+ * in respect to an other geometry stored in a different skd-tree.
+ * \param[in] selection Pointer to skd-tree used as selection patch.
+ * \param[in] target Pointer to skd-tree that store the target geometry.
  * \param[in] tol Distance threshold used to select the elements of target.
- * \return Vector of the label of all the elements of the target skdtree placed
- * at a distance <= tol from the bounding boxes of the leaf nodes of the skdtree
+ * \return Vector of the label of all the elements of the target skd-tree placed
+ * at a distance <= tol from the bounding boxes of the leaf nodes of the skd-tree
  * selection.
  */
 std::vector<long> selectByPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol){
@@ -225,13 +227,13 @@ std::vector<long> selectByPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSk
 }
 
 /*!
- * It extracts the elements of a leaf node of geometry stored in a skdtree
+ * It extracts the elements of a leaf node of geometry stored in a skd-tree
  * by a distance criterion in respect to an other geometry stored
- * in a different skdtree. It is a method used in selectByPatch method.
- * \param[in] target Pointer to skdtree that store the target geometry.
+ * in a different skd-tree. It is a method used in selectByPatch method.
+ * \param[in] target Pointer to skd-tree that store the target geometry.
  * \param[in,out] leafSelection Vector of pointers to the leaf nodes currently interesting
  * for the selection procedure.
- * \param[in,out] extracted of the label of all the elements of the target skdtree,
+ * \param[in,out] extracted of the label of all the elements of the target skd-tree,
  * currently found placed at a distance <= tol from the bounding boxes of the
  * leaf nodes in leafSelection.
  * \param[in] tol Distance threshold used to select the elements of target.
@@ -302,14 +304,14 @@ void extractTarget(bitpit::PatchSkdTree *target, const std::vector<const bitpit:
 }
 
 /*!
- * It computes the projection of a point on a geometry linked in a skdtree
+ * It computes the projection of a point on a geometry linked in a skd-tree
  * object. The geometry must be a surface mesh, in particular an object of type
  * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
  * It searches the elements of the geometry with minimum distance
  * recursively in a sphere of radius r, by increasing the size r at each step
  * until at least one element is found.
- * \param[in] P_ Pointer to coordinates of input point.
- * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
+ * \param[in] point Pointer to coordinates of input point.
+ * \param[in] skdtree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
  * \param[in] r Initial length of the sphere radius used to search. (The algorithm checks
  * every element encountered inside the sphere).
  * \return Coordinates of the projected point.
@@ -323,7 +325,7 @@ darray3E projectPoint(const std::array<double,3> *point, const bitpit::PatchSkdT
 }
 
 /*!
- * It computes the projection of a set of points on a geometry linked in a skdtree
+ * It computes the projection of a set of points on a geometry linked in a skd-tree
  * object. The geometry must be a surface mesh, in particular an object of type
  * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
  * It searches the elements of the geometry with minimum distance
@@ -422,6 +424,15 @@ long locatePointOnPatch(const std::array<double, 3> &point, const bitpit::PatchS
     return id;
 }
 
+/*!
+ * It computes the pseudo-normal of a cell of a surface mesh from an input point,
+ * i.e. the unit vector with direction (P-xP), where P is the input point and
+ * xP is the projection on the cell.
+ * \param[in] point point coordinates
+ * \param[in] surface_mesh pointer to surface mesh
+ * \param[in] id cell id belong to the input surface mesh
+ * \return pseudo-normal components
+ */
 std::array<double, 3>
 computePseudoNormal(const std::array<double, 3> &point, const bitpit::SurfUnstructured *surface_mesh, long id)
 {
@@ -489,6 +500,14 @@ computePseudoNormal(const std::array<double, 3> &point, const bitpit::SurfUnstru
     return pseudo_normal;
 }
 
+/*!
+ * It check if a point belongs to an input cell. If the point is located on the plane of the
+ * cell and inside it, it returns true, false otherwise.
+ * \param[in] point point coordinates
+ * \param[in] surface_mesh pointer to surface mesh
+ * \param[in] cellId cell id belong to the input surface mesh to be checked
+ * \return true if the point belongs to the input cell
+ */
 bool
 checkPointBelongsToCell(const std::array<double, 3> &point, const bitpit::SurfUnstructured *surface_mesh, long cellId)
 {
@@ -523,20 +542,18 @@ checkPointBelongsToCell(const std::array<double, 3> &point, const bitpit::SurfUn
 
 #if MIMMO_ENABLE_MPI
 /*!
- * It computes the unsigned distance of a point to a geometry linked in a SkdTree
+ * It computes the unsigned distance of a set of points to a geometry linked in a SkdTree
  * object. The geometry has to be a surface mesh, in particular an object of type
  * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
  * It searches the element with minimum distance in a box of length 2*r, if none
- * is found return a default value of distance equal to std::numeric_limits<double>::max();
+ * is found return a default value of distance equal to std::numeric_limits<double>::max() in the
+ * position of the distances array related to the input point.
  * \param[in] nP Number of input points.
  * \param[in] points Pointer to coordinates of input points.
  * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
- * \param[out] ids Labels of the elements found as minimum distance element in the bv-tree.
- * \param[out] ranks Ranks of the process owner of the elements found as minimum distance elements in the bv-tree.
- * \param[out] normals Pseudo-normals of the elements (i.e. unit vector with direction (P-xP),
- * where P is the input point and xP the nearest point on the element (simplex) to
- * the projection of P on the plane of the simplex.
- * \param[out] distances Distance of the input points from the patch in the bv-tree.
+ * \param[out] ids Labels of the elements found as minimum distance element in the skd-tree.
+ * \param[out] ranks Ranks of the process owner of the elements found as minimum distance elements in the skd-tree.
+ * \param[out] distances Distance of the input points from the patch in the skd-tree.
  * \param[in] shared True if the input points are shared between the processes
  * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
  * every element encountered inside the box/sphere).
@@ -567,16 +584,17 @@ void globalDistance(std::size_t nP, const std::array<double,3> *points, const bi
  * computed. A positive distance means that the point is located, in respect to the
  * surface mesh, on the same side of the outer normal vector.
  * It searches the element with minimum distance in a box of length 2*r, if none
- * is found return a default value of distance equal to std::numeric_limits<double>::max();
+ * is found return a default value of distance equal to std::numeric_limits<double>::max() in the
+ * position of the distances array related to the input point.
  * \param[in] nP Number of input points.
  * \param[in] points Pointer to coordinates of input points.
  * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
- * \param[out] ids Labels of the elements found as minimum distance element in the bv-tree.
- * \param[out] ranks Ranks of the process owner of the elements found as minimum distance elements in the bv-tree.
+ * \param[out] ids Labels of the elements found as minimum distance element in the skd-tree.
+ * \param[out] ranks Ranks of the process owner of the elements found as minimum distance elements in the skd-tree.
  * \param[out] normals Pseudo-normals of the elements (i.e. unit vector with direction (P-xP),
  * where P is the input point and xP the nearest point on the element (simplex) to
  * the projection of P on the plane of the simplex.
- * \param[out] distances Signed distance of the input points from the patch in the bv-tree.
+ * \param[out] distances Signed distance of the input points from the patch in the skd-tree.
  * \param[in] shared True if the input points are shared between the processes
  * \param[in] r Length of the side of the box or radius of the sphere used to search. (The algorithm checks
  * every element encountered inside the box/sphere).
@@ -725,7 +743,7 @@ void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, co
 }
 
 /*!
- * It computes the projection of a set of points on a geometry linked in a skdtree
+ * It computes the projection of a set of points on a geometry linked in a skd-tree
  * object. The geometry must be a surface mesh, in particular an object of type
  * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
  * It searches the elements of the geometry with minimum distance
@@ -770,7 +788,6 @@ void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, cons
 /*!
  * Given the specified set of points find the cells of a surface patch it is into.
  * The method works only with trees generated with bitpit::SurfUnstructured mesh.
- *
  * \param[in] nP Number of input points
  * \param[in] points is the set of points
  * \param[in] tree pointer to SkdTree relative to the target surface geometry.
@@ -938,13 +955,13 @@ void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points
 }
 
 /*!
- * It selects the elements of a geometry stored in a skdtree by a distance criterion
- * in respect to an other global geometry stored in a different global skdtree.
- * \param[in] selection Pointer to bv-tree used as selection patch.
- * \param[in] target Pointer to bv-tree that store the target geometry.
+ * It selects the elements of a geometry stored in a skd-tree by a distance criterion
+ * in respect to an other global geometry stored in a different global skd-tree.
+ * \param[in] selection Pointer to skd-tree used as selection patch.
+ * \param[in] target Pointer to skd-tree that store the target geometry.
  * \param[in] tol Distance threshold used to select the elements of target.
- * \return Vector of the label of all the local (current rank) elements of the target skdtree placed
- * at a distance <= tol from the bounding boxes of the leaf nodes of the global skdtree
+ * \return Vector of the label of all the local (current rank) elements of the target skd-tree placed
+ * at a distance <= tol from the bounding boxes of the leaf nodes of the global skd-tree
  * selection.
  */
 std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol){
@@ -1068,19 +1085,17 @@ std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::P
 }
 
 /*!
- * It extracts the elements of a leaf node of geometry stored in a skdtree
+ * It extracts the elements of a leaf node of geometry stored in a skd-tree
  * by a distance criterion in respect to an other geometry stored
- * in a different skdtree and passed as vector of bounding boxes. It is a method used in selectByGlobalPatch method.
- * \param[in] target Pointer to skdtree that store the target geometry.
+ * in a different skd-tree and passed as vector of bounding boxes. It is a method used in selectByGlobalPatch method.
+ * \param[in] target Pointer to skd-tree that store the target geometry.
  * \param[in] leafSelection Vector of bounding boxes SkdBox of the leaf nodes currently interesting
  * for the selection procedure.
- * \param[in,out] extracted of the label of all the elements of the target skdtree,
+ * \param[in,out] extracted of the label of all the elements of the target skd-tree,
  * currently found placed at a distance <= tol from the bounding boxes of the
  * leaf nodes in leafSelection.
  * \param[in] tol Distance threshold used to select the elements of target.
  * the next-th node is not a leaf node the method is recursively called.
- *
- *
  */
 void extractTarget(bitpit::PatchSkdTree *target, const std::vector<bitpit::SkdBox> &leafSelectionBoxes, std::vector<long> &extracted, double tol)
 {
@@ -1139,10 +1154,9 @@ void extractTarget(bitpit::PatchSkdTree *target, const std::vector<bitpit::SkdBo
 
 
 /*!
-* Given the specified points, considered shared on the processes, find the
+* Given the specified set of points, considered shared on the processes, find the
 * closest cells contained in the tree and evaluates the distance values
 * between those cells and the given points.
-*
 * \param[in] nPoints number of the points
 * \param[in] points points coordinates
 * \param[in] tree pointer to SkdTree relative to the target surface geometry.

--- a/src/core/SkdTreeUtils.cpp
+++ b/src/core/SkdTreeUtils.cpp
@@ -1431,6 +1431,272 @@ void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<doub
 
 #endif
 
+/*!
+* Given the specified point find the closest cell contained in the
+* three and evaluates the distance between that cell and the given
+* point.
+*
+* \param[in] point is the point
+* \param[in] tree pointer to SkdTree relative to the target volume geometry.
+* \param[out] id on output it will contain the id of the cell closest
+* to the point, if the distance between the point and the surface is
+* greater than the specified maximum distance, the id parameter will
+* be set to the null id
+* \param[in,out] distance on output it will contain the distance
+* between the point and closest cell. If all cells contained in the
+* tree are farther than the maximum distance, the function will return
+* the maximum representable distance.
+*/
+long findPointClosestCell(const std::array<double, 3> &point, const bitpit::VolumeSkdTree *tree, long *id, double *distance)
+{
+    return findPointClosestCell(point, tree, std::numeric_limits<double>::max(), id, distance);
+
+}
+/*!
+* Given the specified point find the closest cell contained in the
+* three and evaluates the distance between that cell and the given
+* point.
+*
+* \param[in] point is the point
+* \param[in] tree pointer to SkdTree relative to the target volume geometry.
+* \param[in] maxDistance all cells whose distance is greater than
+* this parameters will not be considered for the evaluation of the
+* distance
+* \param[out] id on output it will contain the id of the closest cell.
+* If all cells contained in the tree are farther than the maximum
+* distance, the argument will be set to the null id
+* \param[out] distance on output it will contain the distance between
+* the point and closest cell. If all cells contained in the tree are
+* farther than the maximum distance, the argument will be set to the
+* maximum representable distance
+*/
+long findPointClosestCell(const std::array<double, 3> &point, const bitpit::VolumeSkdTree *tree,
+        double maxDistance, long *id, double *distance)
+{
+
+    // Initialize the cell id
+    *id = bitpit::Cell::NULL_ID;
+
+    // Initialize the distance with an estimate
+    //
+    // The real distance will be lesser than or equal to the estimate.
+    std::size_t rootId = 0;
+    const bitpit::SkdNode &root = tree->getNode(rootId);
+    *distance = std::min(root.evalPointMaxDistance(point), maxDistance);
+
+    // Get a list of candidates nodes
+    //
+    // Initialize list of candidates
+    std::vector<std::size_t> candidateIds;
+    std::vector<double> candidateMinDistances;
+
+    std::vector<std::size_t> nodeStack;
+    nodeStack.push_back(rootId);
+    while (!nodeStack.empty()) {
+        std::size_t nodeId = nodeStack.back();
+        const bitpit::SkdNode &node = tree->getNode(nodeId);
+        nodeStack.pop_back();
+
+        // Do not consider nodes with a minimum distance greater than
+        // the distance estimate
+        double nodeMinDistance = node.evalPointMinDistance(point);
+        if (nodeMinDistance > *distance) {
+            continue;
+        }
+
+        // Update the distance estimate
+        //
+        // The real distance will be lesser than or equal to the
+        // estimate.
+        double nodeMaxDistance = node.evalPointMaxDistance(point);
+        *distance = std::min(nodeMaxDistance, *distance);
+
+        // If the node is a leaf add it to the candidates, otherwise
+        // add its children to the stack.
+        bool isLeaf = true;
+        for (int i = bitpit::SkdNode::CHILD_BEGIN; i != bitpit::SkdNode::CHILD_END; ++i) {
+            bitpit::SkdNode::ChildLocation childLocation = static_cast<bitpit::SkdNode::ChildLocation>(i);
+            std::size_t childId = node.getChildId(childLocation);
+            if (childId != bitpit::SkdNode::NULL_ID) {
+                isLeaf = false;
+                nodeStack.push_back(childId);
+            }
+        }
+
+        if (isLeaf) {
+            candidateIds.push_back(nodeId);
+            candidateMinDistances.push_back(nodeMinDistance);
+        }
+    }
+
+    // Process the candidates and find the closest cell
+    long nDistanceEvaluations = 0;
+    for (std::size_t k = 0; k < candidateIds.size(); ++k) {
+        // Do not consider nodes with a minimum distance greater than
+        // the distance estimate
+        if (candidateMinDistances[k] > *distance) {
+            continue;
+        }
+
+        // Evaluate the distance
+        std::size_t nodeId = candidateIds[k];
+        const bitpit::SkdNode &node = tree->getNode(nodeId);
+
+        node.updatePointClosestCell(point, id, distance);
+        ++nDistanceEvaluations;
+    }
+
+    // If no closest cell was found set the distance to the maximum
+    // representable distance.
+    if (*id == bitpit::Cell::NULL_ID) {
+        *distance = std::numeric_limits<double>::max();
+    }
+
+    return nDistanceEvaluations;
+}
+
+#if MIMMO_ENABLE_MPI
+/*!
+* Given the specified points, considered distributed on the processes, find the
+* closest cells contained in the tree and evaluates the distance values
+* between those cells and the given points.
+*
+* \param[in] nPoints number of the points
+* \param[in] points points coordinates
+* \param[in] tree pointer to SkdTree relative to the target volume geometry.
+* \param[out] ids on output it will contain the ids of the cells closest
+* to the local points
+* \param[out] ranks on output it will contain the rank indices of the processes
+* owner of the cells closest to the points
+* \param[out] distances on output it will contain the distances
+* between the points and closest cells
+*/
+void findPointClosestGlobalCell(const std::size_t nPoints, const std::array<double, 3> *points,
+        const bitpit::VolumeSkdTree *tree, long *ids, int *ranks, double *distances)
+{
+    std::vector<double> maxDistances(nPoints, std::numeric_limits<double>::max());
+
+    // Patch is partitioned call the parallel method
+    if (!tree->getPatch().isCommunicatorSet()){
+        throw std::runtime_error ("There is no communicator set for the patch.");
+    }
+
+    int nprocs = tree->getPatch().getProcessorCount();
+    int myRank = tree->getPatch().getRank();
+
+    // Initialize the cell ids and ranks
+    for (std::size_t i = 0; i < nPoints; i++){
+        ids[i] = bitpit::Cell::NULL_ID;
+        ranks[i] = -1;
+    }
+
+    // Communicate all the points to all the processes
+    // Gather number of points multiplied by number of coordinates,
+    // i.e. number of data to communicate
+    std::vector<int> pointsCount(nprocs);
+    MPI_Allgather(&nPoints, 1, MPI_INT, pointsCount.data(), 1, MPI_INT, tree->getCommunicator());
+
+    // Recover points displacements, offset and number of points data per process
+    std::vector<int> pointsDispls(nprocs, 0);
+    std::vector<int> pointsOffsets(nprocs, 0);
+    std::vector<int> pointsCountData(nprocs, 0);
+    pointsCountData[0] = pointsCount[0] * 3;
+    for (int i = 1; i < nprocs; ++i) {
+        pointsDispls[i] = pointsDispls[i - 1] + pointsCount[i - 1] * 3;
+        pointsOffsets[i] = pointsOffsets[i - 1] + pointsCount[i - 1];
+        pointsCountData[i] = pointsCount[i] * 3;
+    }
+
+    // Sum to global number of points
+    int nGlobalPoints = 0;
+    for (int np : pointsCount){
+        nGlobalPoints += np;
+    }
+
+    // Gather vector with all global points
+    std::vector<std::array<double,3>> globalPoints(nGlobalPoints);
+    std::size_t nPointsCountData = nPoints * 3;
+    MPI_Allgatherv(points, nPointsCountData, MPI_DOUBLE, globalPoints.data(),
+            pointsCountData.data(), pointsDispls.data(), MPI_DOUBLE, tree->getCommunicator());
+
+    // Gather vector with all maximum distances
+    std::vector<double> globalMaxDistances(nGlobalPoints);
+    MPI_Allgatherv(maxDistances.data(), nPoints, MPI_DOUBLE, globalMaxDistances.data(),
+            pointsCount.data(), pointsOffsets.data(), MPI_DOUBLE, tree->getCommunicator());
+
+    // Call local find point closest cell for each global point collected
+
+    // Instantiate global container for distances, ids and ranks (SkdCellInfo)
+    std::vector<bitpit::PatchSkdTree::SkdCellInfo> dri_data(nGlobalPoints, bitpit::PatchSkdTree::SkdCellInfo(std::numeric_limits<double>::max(), myRank, bitpit::Cell::NULL_ID));
+
+    // Call local find point closest cell for each global point collected
+    for (std::size_t ip = 0; ip < nGlobalPoints; ip++){
+
+        const std::array<double,3> & point = globalPoints[ip];
+        double & distance = dri_data[ip].distance;
+        int & rank = dri_data[ip].rank;
+        long & id = dri_data[ip].id;
+
+        // Use a maximum distance for each point given by an estimation based on partition
+        // bounding boxes. The distance will be lesser than or equal to the point maximum distance
+        double pointMaxDistance = globalMaxDistances[ip];
+        for (int irank = 0; irank < nprocs; irank++){
+            pointMaxDistance = std::min(tree->getPartitionBox(irank).evalPointMaxDistance(point), pointMaxDistance);
+        }
+
+        // Call local find point closest cell with estimated distance used as maximum distance
+        long nDistanceEvaluations = findPointClosestCell(point, tree, pointMaxDistance, &id, &distance);
+
+    }
+
+    // Force distance to numeric limits maximum value for point projected on ghost cells
+    // The desired result id is the local cell id on the ghost owner rank
+    for (std::size_t ip = 0; ip < nGlobalPoints; ip++){
+        long cellId = dri_data[ip].id;
+        if(cellId != bitpit::Cell::NULL_ID && !tree->getPatch().getCell(cellId).isInterior()) {
+            dri_data[ip].id = tree->getGhostCellsRemoteIds().at(cellId);
+            dri_data[ip].rank = tree->getPatch().getCellRank(cellId);
+        }
+    }
+
+    // Communicate the computed distances of the distributed input points to all processes
+    // and retain the indices of the rank owner and the id of the closest cell
+
+    // Prepare MPI custom data type and Operation
+    // The data are of MPI custom data type  with distance, ids and rank as member
+    int blocklengths[3] = {1,1,1};
+    MPI_Aint displacements[3] = {offsetof(bitpit::PatchSkdTree::SkdCellInfo, distance),
+            offsetof(bitpit::PatchSkdTree::SkdCellInfo, rank),
+            offsetof(bitpit::PatchSkdTree::SkdCellInfo, id)};
+    MPI_Datatype types[3] = {MPI_DOUBLE, MPI_INT, MPI_LONG};
+    MPI_Datatype MPI_DRI;
+    MPI_Type_create_struct(3, blocklengths, displacements, types, &MPI_DRI);
+    MPI_Type_commit(&MPI_DRI);
+
+    MPI_Op MPI_MIN_DRI;
+    MPI_Op_create((MPI_User_function *) bitpit::minSkdCellInfo, false, &MPI_MIN_DRI);
+
+    // Communicate the closest cells distances, ranks and ids by reduce with custom minimum distance operation
+    // Reduce only the right portion of data to the right process
+    for (int irank = 0; irank < nprocs; irank++){
+        bitpit::PatchSkdTree::SkdCellInfo *buffer = (dri_data.data() + pointsOffsets[irank]);
+        if (myRank == irank){
+            MPI_Reduce(MPI_IN_PLACE, buffer, pointsCount[irank], MPI_DRI, MPI_MIN_DRI, irank, tree->getCommunicator());
+        } else {
+            MPI_Reduce(buffer, buffer, pointsCount[irank], MPI_DRI, MPI_MIN_DRI, irank, tree->getCommunicator());
+        }
+    }
+
+    // Update distances, rank indices and cell ids
+    for (std::size_t ip = 0; ip < nPoints; ip++){
+        std::size_t globalIndex = ip + pointsOffsets[myRank];
+        distances[ip] = dri_data[globalIndex].distance;
+        ranks[ip] = dri_data[globalIndex].rank;
+        ids[ip] = dri_data[globalIndex].id;
+    }
+
+}
+#endif
 }
 
 }; // end namespace mimmo

--- a/src/core/SkdTreeUtils.cpp
+++ b/src/core/SkdTreeUtils.cpp
@@ -1369,8 +1369,10 @@ long findSharedPointClosestGlobalCell(int nPoints, const std::array<double, 3> *
             // The patch is not partitioned, all cells are local
             ranks[i] = patch.getRank();
 
-            return nDistanceEvaluations;
         }
+
+        return nDistanceEvaluations;
+
     }
 
     // Get MPI communicator
@@ -1598,8 +1600,10 @@ long findPointClosestGlobalCell(int nPoints, const std::array<double, 3> *points
             // The patch is not partitioned, all cells are local
             ranks[i] = patch.getRank();
 
-            return nDistanceEvaluations;
         }
+
+        return nDistanceEvaluations;
+
     }
 
     // Get MPI communicator

--- a/src/core/SkdTreeUtils.cpp
+++ b/src/core/SkdTreeUtils.cpp
@@ -614,12 +614,8 @@ checkPointBelongsToCell(const std::array<double, 3> &point, const bitpit::SurfUn
 
 #if MIMMO_ENABLE_MPI
 /*!
- * It computes the unsigned distance of a set of points to a geometry linked in a SkdTree
- * object. The geometry has to be a surface mesh, in particular an object of type
- * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
- * It searches the element with minimum distance in a box of length 2*r, if none
- * is found return a default value of distance equal to std::numeric_limits<double>::max() in the
- * position of the distances array related to the input point.
+ * It computes the unsigned distance of a set of points to a distributed geometry linked in a SkdTree
+ * object. Analogous of serial function skdTreeUtils::distance.
  * \param[in] nP Number of input points.
  * \param[in] points Pointer to coordinates of input points.
  * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
@@ -637,12 +633,8 @@ void globalDistance(std::size_t nP, const std::array<double,3> *points, const bi
 }
 
 /*!
- * It computes the unsigned distance of a set of points to a geometry linked in a SkdTree
- * object. The geometry has to be a surface mesh, in particular an object of type
- * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
- * It searches the element with minimum distance in a box of length 2*r, if none
- * is found return a default value of distance equal to std::numeric_limits<double>::max() in the
- * position of the distances array related to the input point.
+ * It computes the unsigned distance of a set of points to a distributed geometry linked in a SkdTree
+ * object. Analogous of serial function skdTreeUtils::distance.
  * \param[in] nP Number of input points.
  * \param[in] points Pointer to coordinates of input points.
  * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
@@ -671,17 +663,9 @@ void globalDistance(std::size_t nP, const std::array<double,3> *points, const bi
 
 }
 
-
 /*!
- * It computes the signed global distance of a set of points to a geometry linked in a SkdTree
- * object. The geometry must be a surface mesh, in particular an object of type
- * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
- * The sign of the distance is provided by the normal to the geometry locally
- * computed. A positive distance means that the point is located, in respect to the
- * surface mesh, on the same side of the outer normal vector.
- * It searches the element with minimum distance in a box of length 2*r, if none
- * is found return a default value of distance equal to std::numeric_limits<double>::max() in the
- * position of the distances array related to the input point.
+ * It computes the signed global distance of a set of points to a distributed geometry linked in a SkdTree
+ * object. Analogous of serial function skdTreeUtils::signedDistance.
  * \param[in] nP Number of input points.
  * \param[in] points Pointer to coordinates of input points.
  * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
@@ -702,15 +686,8 @@ void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, co
 }
 
 /*!
- * It computes the signed global distance of a set of points to a geometry linked in a SkdTree
- * object. The geometry must be a surface mesh, in particular an object of type
- * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
- * The sign of the distance is provided by the normal to the geometry locally
- * computed. A positive distance means that the point is located, in respect to the
- * surface mesh, on the same side of the outer normal vector.
- * It searches the element with minimum distance in a box of length 2*r, if none
- * is found return a default value of distance equal to std::numeric_limits<double>::max() in the
- * position of the distances array related to the input point.
+ * It computes the signed global distance of a set of points to a distributed geometry linked in a SkdTree
+ * object. Analogous of serial function skdTreeUtils::signedDistance.
  * \param[in] nP Number of input points.
  * \param[in] points Pointer to coordinates of input points.
  * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
@@ -868,12 +845,8 @@ void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, co
 }
 
 /*!
- * It computes the projection of a set of points on a geometry linked in a skd-tree
- * object. The geometry must be a surface mesh, in particular an object of type
- * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
- * It searches the elements of the geometry with minimum distance
- * recursively in a sphere of radius r, by increasing the size r at each step
- * until at least one element is found.
+ * It computes the projection of a set of points on a distributed geometry linked in a skd-tree
+ * object. Analogous of serial function skdTreeUtils::projectPoint.
  * \param[in] nP Number of input points.
  * \param[in] points Pointer to coordinates of input points.
  * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
@@ -890,12 +863,8 @@ void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, cons
 }
 
 /*!
- * It computes the projection of a set of points on a geometry linked in a skd-tree
- * object. The geometry must be a surface mesh, in particular an object of type
- * bitpit::SurfUnstructured (a static cast is hardly coded in the method).
- * It searches the elements of the geometry with minimum distance
- * recursively in a sphere of radius r, by increasing the size r at each step
- * until at least one element is found.
+ * It computes the projection of a set of points on a distributed geometry linked in a skd-tree
+ * object. Analogous of serial function skdTreeUtils::projectPoint.
  * \param[in] nP Number of input points.
  * \param[in] points Pointer to coordinates of input points.
  * \param[in] tree Pointer to Boundary Volume Hierarchy tree that stores the geometry.
@@ -936,8 +905,8 @@ void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, cons
 }
 
 /*!
- * Given the specified set of points find the cells of a surface patch it is into.
- * The method works only with trees generated with bitpit::SurfUnstructured mesh.
+ * Given the specified set of points find the cells of a distributed surface patch it is into.
+ * Analogous of serial function skdTreeUtils::locatePointOnPatch.
  * \param[in] nP Number of input points
  * \param[in] points is the set of points
  * \param[in] tree pointer to SkdTree relative to the target surface geometry.
@@ -1105,8 +1074,9 @@ void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points
 }
 
 /*!
- * It selects the elements of a geometry stored in a skd-tree by a distance criterion
- * in respect to an other global geometry stored in a different global skd-tree.
+ * It selects the elements of a distributed geometry stored in a skd-tree by a distance criterion
+ * in respect to an other distributed geometry stored in a different global skd-tree.
+ * Analogous of serial function skdTreeUtils::selectByPatch.
  * \param[in] selection Pointer to skd-tree used as selection patch.
  * \param[in] target Pointer to skd-tree that store the target geometry.
  * \param[in] tol Distance threshold used to select the elements of target.
@@ -1235,9 +1205,10 @@ std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::P
 }
 
 /*!
- * It extracts the elements of a leaf node of geometry stored in a skd-tree
- * by a distance criterion in respect to an other geometry stored
- * in a different skd-tree and passed as vector of bounding boxes. It is a method used in selectByGlobalPatch method.
+ * It extracts the elements of a leaf node of a distributed geometry stored in a skd-tree
+ * by a distance criterion in respect to an other distributed geometry stored
+ * in a different skd-tree and passed as vector of bounding boxes.
+ * It is a method used in skdTreeUtils::selectByGlobalPatch method.
  * \param[in] target Pointer to skd-tree that store the target geometry.
  * \param[in] leafSelection Vector of bounding boxes SkdBox of the leaf nodes currently interesting
  * for the selection procedure.
@@ -1305,7 +1276,7 @@ void extractTarget(bitpit::PatchSkdTree *target, const std::vector<bitpit::SkdBo
 
 /*!
 * Given the specified set of points, considered shared on the processes, find the
-* closest cells contained in the tree and evaluates the distance values
+* closest cells contained in a distributed skd-tree and evaluates the distance values
 * between those cells and the given points.
 * \param[in] nPoints number of the points
 * \param[in] points points coordinates
@@ -1332,7 +1303,7 @@ void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<doub
 
 /*!
 * Given the specified set of points, considered shared on the processes, find the
-* closest cells contained in the tree and evaluates the distance values
+* closest cells contained in a distributed skd-tree and evaluates the distance values
 * between those cells and the given points.
 * \param[in] nPoints number of the points
 * \param[in] points points coordinates
@@ -1432,10 +1403,9 @@ void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<doub
 #endif
 
 /*!
-* Given the specified point find the closest cell contained in the
-* three and evaluates the distance between that cell and the given
+* Given the specified point find the closest cell contained in a
+* skd-tree and evaluates the distance between that cell and the given
 * point.
-*
 * \param[in] point is the point
 * \param[in] tree pointer to SkdTree relative to the target volume geometry.
 * \param[out] id on output it will contain the id of the cell closest
@@ -1453,10 +1423,9 @@ long findPointClosestCell(const std::array<double, 3> &point, const bitpit::Volu
 
 }
 /*!
-* Given the specified point find the closest cell contained in the
-* three and evaluates the distance between that cell and the given
+* Given the specified point find the closest cell contained in a
+* skd-tree and evaluates the distance between that cell and the given
 * point.
-*
 * \param[in] point is the point
 * \param[in] tree pointer to SkdTree relative to the target volume geometry.
 * \param[in] maxDistance all cells whose distance is greater than
@@ -1558,9 +1527,8 @@ long findPointClosestCell(const std::array<double, 3> &point, const bitpit::Volu
 #if MIMMO_ENABLE_MPI
 /*!
 * Given the specified points, considered distributed on the processes, find the
-* closest cells contained in the tree and evaluates the distance values
+* closest cells contained in a distributed skd-tree and evaluates the distance values
 * between those cells and the given points.
-*
 * \param[in] nPoints number of the points
 * \param[in] points points coordinates
 * \param[in] tree pointer to SkdTree relative to the target volume geometry.

--- a/src/core/SkdTreeUtils.cpp
+++ b/src/core/SkdTreeUtils.cpp
@@ -1116,8 +1116,11 @@ void locatePointOnGlobalPatch(int nP, const std::array<double,3> *points, const 
  */
 std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol){
 
-    if (!selection->getPatch().isPartitioned() || !target->getPatch().isPartitioned()){
-        throw std::runtime_error("Error: the two PatchSkdTree communicators not set in selectByGlobalPatch");
+    if (!selection->getPatch().isPartitioned()){
+        throw std::runtime_error("Error: selection PatchSkdTree communicators not set in selectByGlobalPatch");
+    }
+    if (!target->getPatch().isPartitioned()){
+        throw std::runtime_error("Error: target PatchSkdTree communicators not set in selectByGlobalPatch");
     }
 
     //TODO USE THE REAL IS DISTRIBUTED PATCH IN BITPIT WHEN READY !!!!

--- a/src/core/SkdTreeUtils.cpp
+++ b/src/core/SkdTreeUtils.cpp
@@ -717,7 +717,9 @@ void signedGlobalDistance(int nP, const std::array<double,3> *points, const bitp
         static_cast<const bitpit::SurfaceSkdTree*>(tree)->findPointClosestGlobalCell(nP, points, r, ids, ranks, distances);
     }
 
+
     int myrank = spatch.getRank();
+
 
     // Map with rank to ask info in case of distributed points
     std::map<int,std::vector<long>> ask_to_rank;
@@ -770,7 +772,7 @@ void signedGlobalDistance(int nP, const std::array<double,3> *points, const bitp
 
     int nProcessors = spatch.getProcessorCount();
 
-    if (nProcessors > 1 && spatch.isPartitioned()){
+    if (nProcessors > 1 && spatch.isCommunicatorSet()){
         if (shared){
 
             // If all points are shared between processes all reduce on normal by minimum operation
@@ -824,7 +826,7 @@ void signedGlobalDistance(int nP, const std::array<double,3> *points, const bitp
 
             for (int irank = 0; irank < nProcessors; irank++){
                 normal_to_rank[irank].resize(n_send_to_rank[irank], std::array<double,3>({std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), std::numeric_limits<double>::max()}));
-                sign_to_rank[irank].resize(n_send_to_rank[irank], 1.);
+                sign_to_rank[irank].resize(n_send_to_rank[irank], std::numeric_limits<double>::max());
                 for (int ip = 0; ip < n_send_to_rank[irank]; ip++){
 
                     const std::array<double,3> & point = point_from_rank[irank][ip];

--- a/src/core/SkdTreeUtils.hpp
+++ b/src/core/SkdTreeUtils.hpp
@@ -45,7 +45,6 @@ namespace skdTreeUtils{
     std::array<double,3> projectPoint(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, double r = 1.0e+18);
     void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double r = 1.0e+18);
     long locatePointOnPatch(const std::array<double, 3> &point, const bitpit::PatchSkdTree *tree);
-    long closestCellToPoint(const std::array<double, 3> &point, bitpit::PatchSkdTree &tree);
 
     std::array<double, 3> computePseudoNormal(const std::array<double,3> &point, const bitpit::SurfUnstructured *surface_mesh, long id);
     bool checkPointBelongsToCell(const std::array<double, 3> &point, const bitpit::SurfUnstructured *surface_mesh, long id);

--- a/src/core/SkdTreeUtils.hpp
+++ b/src/core/SkdTreeUtils.hpp
@@ -38,39 +38,39 @@ namespace skdTreeUtils{
 
     double distance(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long &id, double r);
     double signedDistance(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long &id, std::array<double,3> &normal, double r);
-    void distance(std::size_t nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *id, double *distances, double r);
-    void distance(std::size_t nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *id, double *distances, double *r);
-    void signedDistance(std::size_t nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *ids, double *distances, std::array<double,3> *normals, double r);
-    void signedDistance(std::size_t nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *ids, double *distances, std::array<double,3> *normals, double *r);
+    void distance(int nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *id, double *distances, double r);
+    void distance(int nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *id, double *distances, double *r);
+    void signedDistance(int nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *ids, double *distances, std::array<double,3> *normals, double r);
+    void signedDistance(int nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *ids, double *distances, std::array<double,3> *normals, double *r);
     std::vector<long> selectByPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol = 1.0e-04);
     void extractTarget(bitpit::PatchSkdTree *target, const std::vector<const bitpit::SkdNode*> & leafSelection, std::vector<long> &extracted, double tol);
     std::array<double,3> projectPoint(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, double r = std::numeric_limits<double>::max());
-    void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double r = std::numeric_limits<double>::max());
-    void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double* r);
+    void projectPoint(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double r = std::numeric_limits<double>::max());
+    void projectPoint(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double* r);
     long locatePointOnPatch(const std::array<double, 3> &point, const bitpit::PatchSkdTree *tree);
 
     std::array<double, 3> computePseudoNormal(const std::array<double,3> &point, const bitpit::SurfUnstructured *surface_mesh, long id);
     bool checkPointBelongsToCell(const std::array<double, 3> &point, const bitpit::SurfUnstructured *surface_mesh, long id);
 
 #if MIMMO_ENABLE_MPI
-    void globalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double r, bool shared = false);
-    void globalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double* r, bool shared = false);
-    void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, std::array<double,3> *normals, double *distances, double r, bool shared = false);
-    void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, std::array<double,3> *normals, double *distances, double* r, bool shared = false);
-    void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, int *ranks, double r = std::numeric_limits<double>::max(), bool shared = false);
-    void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, int *ranks, double* r, bool shared = false);
-    void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, bool shared = false);
+    void globalDistance(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double r, bool shared = false);
+    void globalDistance(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double* r, bool shared = false);
+    void signedGlobalDistance(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, std::array<double,3> *normals, double *distances, double r, bool shared = false);
+    void signedGlobalDistance(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, std::array<double,3> *normals, double *distances, double* r, bool shared = false);
+    void projectPointGlobal(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, int *ranks, double r = std::numeric_limits<double>::max(), bool shared = false);
+    void projectPointGlobal(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, int *ranks, double* r, bool shared = false);
+    void locatePointOnGlobalPatch(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, bool shared = false);
     std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol = 1.0e-04);
     void extractTarget(bitpit::PatchSkdTree *target, const std::vector<bitpit::SkdBox> &leafSelectionBoxes, std::vector<long> &extracted, double tol);
-    void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<double, 3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double r = std::numeric_limits<double>::max());
-    void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<double, 3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double *r);
+    long findSharedPointClosestGlobalCell(int nPoints, const std::array<double, 3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double r = std::numeric_limits<double>::max());
+    long findSharedPointClosestGlobalCell(int nPoints, const std::array<double, 3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double *r);
 #endif
 
     // Functions to allow the use with volume patches (currently not allowed in bitpit)
-    long findPointClosestCell(const std::array<double,3> &point, const bitpit::VolumeSkdTree *tree, long *id, double *distance);
-    long findPointClosestCell(const std::array<double,3> &point, const bitpit::VolumeSkdTree *tree, double maxDistance, long *id, double *distance);
+    long findPointClosestCell(const std::array<double,3> &point, const bitpit::PatchSkdTree *tree, bool interiorOnly, long *id, double *distance);
+    long findPointClosestCell(const std::array<double,3> &point, const bitpit::PatchSkdTree *tree, double maxDistance, bool interiorOnly, long *id, double *distance);
 #if MIMMO_ENABLE_MPI
-    void findPointClosestGlobalCell(const std::size_t nPoints, const std::array<double, 3> *points, const bitpit::VolumeSkdTree *tree, long *ids, int *ranks, double *distances);
+    long findPointClosestGlobalCell(int nPoints, const std::array<double, 3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances);
 #endif
 
 }; //end namespace skdTreeUtils

--- a/src/core/SkdTreeUtils.hpp
+++ b/src/core/SkdTreeUtils.hpp
@@ -25,6 +25,7 @@
 # define __SKDTREEUTILS_HPP__
 
 # include <patch_skd_tree.hpp>
+# include <surfunstructured.hpp>
 
 namespace mimmo{
 
@@ -35,13 +36,29 @@ namespace mimmo{
  */
 namespace skdTreeUtils{
 
-    double distance(std::array<double,3> *P_, bitpit::PatchSkdTree *bvtree_, long &id, double &r);
-    double signedDistance(std::array<double,3> *P_, bitpit::PatchSkdTree *bvtree_, long &id, std::array<double,3> &n, double &r);
+    double distance(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long &id, double r);
+    double signedDistance(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long &id, std::array<double,3> &normal, double r);
+    void distance(std::size_t nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *id, double *distances, double r);
+    double signedDistance(std::size_t nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *ids, double *distances, std::array<double,3> *normals, double r);
     std::vector<long> selectByPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol = 1.0e-04);
     void extractTarget(bitpit::PatchSkdTree *target, const std::vector<const bitpit::SkdNode*> & leafSelection, std::vector<long> &extracted, double tol);
-    std::array<double,3> projectPoint(std::array<double,3> *P_, bitpit::PatchSkdTree *bvtree_, double r_ = 1.0e+18);
-    long locatePointOnPatch(const std::array<double, 3> &point, bitpit::PatchSkdTree &tree);
+    std::array<double,3> projectPoint(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, double r = 1.0e+18);
+    void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double r = 1.0e+18);
+    long locatePointOnPatch(const std::array<double, 3> &point, const bitpit::PatchSkdTree *tree);
     long closestCellToPoint(const std::array<double, 3> &point, bitpit::PatchSkdTree &tree);
+
+    std::array<double, 3> computePseudoNormal(const std::array<double,3> &point, const bitpit::SurfUnstructured *surface_mesh, long id);
+    bool checkPointBelongsToCell(const std::array<double, 3> &point, const bitpit::SurfUnstructured *surface_mesh, long id);
+
+#if MIMMO_ENABLE_MPI
+    void globalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double r, bool shared = false);
+    void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, std::array<double,3> *normals, double *distances, double r, bool shared = false);
+    void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, int *ranks, double r = std::numeric_limits<double>::max(), bool shared = false);
+    void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, bool shared = false);
+    std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol = 1.0e-04);
+    void extractTarget(bitpit::PatchSkdTree *target, const std::vector<bitpit::SkdBox> &leafSelectionBoxes, std::vector<long> &extracted, double tol);
+#endif
+
 }; //end namespace skdTreeUtils
 
 } //end namespace mimmo

--- a/src/core/SkdTreeUtils.hpp
+++ b/src/core/SkdTreeUtils.hpp
@@ -49,7 +49,7 @@ namespace skdTreeUtils{
     void projectPoint(int nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double* r);
     long locatePointOnPatch(const std::array<double, 3> &point, const bitpit::PatchSkdTree *tree);
 
-    std::array<double, 3> computePseudoNormal(const std::array<double,3> &point, const bitpit::SurfUnstructured *surface_mesh, long id);
+    double computePseudoNormal(const std::array<double,3> &point, const bitpit::SurfUnstructured *surface_mesh, long id, std::array<double, 3> & pseudo_normal);
     bool checkPointBelongsToCell(const std::array<double, 3> &point, const bitpit::SurfUnstructured *surface_mesh, long id);
 
 #if MIMMO_ENABLE_MPI

--- a/src/core/SkdTreeUtils.hpp
+++ b/src/core/SkdTreeUtils.hpp
@@ -66,6 +66,13 @@ namespace skdTreeUtils{
     void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<double, 3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double *r);
 #endif
 
+    // Functions to allow the use with volume patches (currently not allowed in bitpit)
+    long findPointClosestCell(const std::array<double,3> &point, const bitpit::VolumeSkdTree *tree, long *id, double *distance);
+    long findPointClosestCell(const std::array<double,3> &point, const bitpit::VolumeSkdTree *tree, double maxDistance, long *id, double *distance);
+#if MIMMO_ENABLE_MPI
+    void findPointClosestGlobalCell(const std::size_t nPoints, const std::array<double, 3> *points, const bitpit::VolumeSkdTree *tree, long *ids, int *ranks, double *distances);
+#endif
+
 }; //end namespace skdTreeUtils
 
 } //end namespace mimmo

--- a/src/core/SkdTreeUtils.hpp
+++ b/src/core/SkdTreeUtils.hpp
@@ -39,11 +39,14 @@ namespace skdTreeUtils{
     double distance(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long &id, double r);
     double signedDistance(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long &id, std::array<double,3> &normal, double r);
     void distance(std::size_t nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *id, double *distances, double r);
-    double signedDistance(std::size_t nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *ids, double *distances, std::array<double,3> *normals, double r);
+    void distance(std::size_t nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *id, double *distances, double *r);
+    void signedDistance(std::size_t nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *ids, double *distances, std::array<double,3> *normals, double r);
+    void signedDistance(std::size_t nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *ids, double *distances, std::array<double,3> *normals, double *r);
     std::vector<long> selectByPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol = 1.0e-04);
     void extractTarget(bitpit::PatchSkdTree *target, const std::vector<const bitpit::SkdNode*> & leafSelection, std::vector<long> &extracted, double tol);
     std::array<double,3> projectPoint(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, double r = std::numeric_limits<double>::max());
     void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double r = std::numeric_limits<double>::max());
+    void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double* r);
     long locatePointOnPatch(const std::array<double, 3> &point, const bitpit::PatchSkdTree *tree);
 
     std::array<double, 3> computePseudoNormal(const std::array<double,3> &point, const bitpit::SurfUnstructured *surface_mesh, long id);
@@ -51,12 +54,16 @@ namespace skdTreeUtils{
 
 #if MIMMO_ENABLE_MPI
     void globalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double r, bool shared = false);
+    void globalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double* r, bool shared = false);
     void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, std::array<double,3> *normals, double *distances, double r, bool shared = false);
+    void signedGlobalDistance(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, std::array<double,3> *normals, double *distances, double* r, bool shared = false);
     void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, int *ranks, double r = std::numeric_limits<double>::max(), bool shared = false);
+    void projectPointGlobal(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, int *ranks, double* r, bool shared = false);
     void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, bool shared = false);
     std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol = 1.0e-04);
     void extractTarget(bitpit::PatchSkdTree *target, const std::vector<bitpit::SkdBox> &leafSelectionBoxes, std::vector<long> &extracted, double tol);
     void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<double, 3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double r = std::numeric_limits<double>::max());
+    void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<double, 3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double *r);
 #endif
 
 }; //end namespace skdTreeUtils

--- a/src/core/SkdTreeUtils.hpp
+++ b/src/core/SkdTreeUtils.hpp
@@ -42,8 +42,8 @@ namespace skdTreeUtils{
     double signedDistance(std::size_t nP, const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, long *ids, double *distances, std::array<double,3> *normals, double r);
     std::vector<long> selectByPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol = 1.0e-04);
     void extractTarget(bitpit::PatchSkdTree *target, const std::vector<const bitpit::SkdNode*> & leafSelection, std::vector<long> &extracted, double tol);
-    std::array<double,3> projectPoint(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, double r = 1.0e+18);
-    void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double r = 1.0e+18);
+    std::array<double,3> projectPoint(const std::array<double,3> *point, const bitpit::PatchSkdTree *tree, double r = std::numeric_limits<double>::max());
+    void projectPoint(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, std::array<double,3> *projected_points, long *ids, double r = std::numeric_limits<double>::max());
     long locatePointOnPatch(const std::array<double, 3> &point, const bitpit::PatchSkdTree *tree);
 
     std::array<double, 3> computePseudoNormal(const std::array<double,3> &point, const bitpit::SurfUnstructured *surface_mesh, long id);
@@ -56,6 +56,7 @@ namespace skdTreeUtils{
     void locatePointOnGlobalPatch(std::size_t nP, const std::array<double,3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, bool shared = false);
     std::vector<long> selectByGlobalPatch(bitpit::PatchSkdTree *selection, bitpit::PatchSkdTree *target, double tol = 1.0e-04);
     void extractTarget(bitpit::PatchSkdTree *target, const std::vector<bitpit::SkdBox> &leafSelectionBoxes, std::vector<long> &extracted, double tol);
+    void findSharedPointClosestGlobalCell(std::size_t nPoints, const std::array<double, 3> *points, const bitpit::PatchSkdTree *tree, long *ids, int *ranks, double *distances, double r = std::numeric_limits<double>::max());
 #endif
 
 }; //end namespace skdTreeUtils

--- a/src/geohandlers/ExtractLongField.cpp
+++ b/src/geohandlers/ExtractLongField.cpp
@@ -301,7 +301,11 @@ void ExtractLongField::extractMapping(mimmo::MPVLocation loc){
 
     if(! m_field.getGeometry()->isSkdTreeSync())  m_field.getGeometry()->buildSkdTree();
     if(! getGeometry()->isSkdTreeSync())          getGeometry()->buildSkdTree();
+#if MIMMO_ENABLE_MPI
+    livector1D cellExtracted = mimmo::skdTreeUtils::selectByGlobalPatch(m_field.getGeometry()->getSkdTree(), getGeometry()->getSkdTree(), m_tol);
+#else
     livector1D cellExtracted = mimmo::skdTreeUtils::selectByPatch(m_field.getGeometry()->getSkdTree(), getGeometry()->getSkdTree(), m_tol);
+#endif
 
     switch(loc){
         case mimmo::MPVLocation::POINT:

--- a/src/geohandlers/ExtractScalarField.cpp
+++ b/src/geohandlers/ExtractScalarField.cpp
@@ -301,7 +301,11 @@ void ExtractScalarField::extractMapping(mimmo::MPVLocation loc){
 
     if(! m_field.getGeometry()->isSkdTreeSync())  m_field.getGeometry()->buildSkdTree();
     if(! getGeometry()->isSkdTreeSync())          getGeometry()->buildSkdTree();
+#if MIMMO_ENABLE_MPI
+    livector1D cellExtracted = mimmo::skdTreeUtils::selectByGlobalPatch(m_field.getGeometry()->getSkdTree(), getGeometry()->getSkdTree(), m_tol);
+#else
     livector1D cellExtracted = mimmo::skdTreeUtils::selectByPatch(m_field.getGeometry()->getSkdTree(), getGeometry()->getSkdTree(), m_tol);
+#endif
 
     switch(loc){
         case mimmo::MPVLocation::POINT:

--- a/src/geohandlers/ExtractStringField.cpp
+++ b/src/geohandlers/ExtractStringField.cpp
@@ -301,7 +301,11 @@ void ExtractStringField::extractMapping(mimmo::MPVLocation loc){
 
     if(! m_field.getGeometry()->isSkdTreeSync())  m_field.getGeometry()->buildSkdTree();
     if(! getGeometry()->isSkdTreeSync())          getGeometry()->buildSkdTree();
+#if MIMMO_ENABLE_MPI
+    livector1D cellExtracted = mimmo::skdTreeUtils::selectByGlobalPatch(m_field.getGeometry()->getSkdTree(), getGeometry()->getSkdTree(), m_tol);
+#else
     livector1D cellExtracted = mimmo::skdTreeUtils::selectByPatch(m_field.getGeometry()->getSkdTree(), getGeometry()->getSkdTree(), m_tol);
+#endif
 
     switch(loc){
         case mimmo::MPVLocation::POINT:

--- a/src/geohandlers/ExtractVectorField.cpp
+++ b/src/geohandlers/ExtractVectorField.cpp
@@ -299,7 +299,12 @@ void ExtractVectorField::extractMapping(mimmo::MPVLocation loc){
 
     if(! m_field.getGeometry()->isSkdTreeSync())  m_field.getGeometry()->buildSkdTree();
     if(! getGeometry()->isSkdTreeSync())          getGeometry()->buildSkdTree();
+
+#if MIMMO_ENABLE_MPI
+    livector1D cellExtracted = mimmo::skdTreeUtils::selectByGlobalPatch(m_field.getGeometry()->getSkdTree(), getGeometry()->getSkdTree(), m_tol);
+#else
     livector1D cellExtracted = mimmo::skdTreeUtils::selectByPatch(m_field.getGeometry()->getSkdTree(), getGeometry()->getSkdTree(), m_tol);
+#endif
 
     switch(loc){
         case mimmo::MPVLocation::POINT:

--- a/src/geohandlers/RefineGeometry.cpp
+++ b/src/geohandlers/RefineGeometry.cpp
@@ -865,7 +865,10 @@ RefineGeometry::smoothing(std::set<long> * constrainedVertices)
 			for (long id : geometry->getVertices().getIds()){
 				geometry->modifyVertex(newcoordinates[id], id);
 			}
-
+#if MIMMO_ENABLE_MPI
+			geometry->cleanAllParallelSync();
+			geometry->updatePointGhostExchangeInfo();
+#endif
 		}
 
 		{
@@ -903,7 +906,10 @@ RefineGeometry::smoothing(std::set<long> * constrainedVertices)
 			for (long id : geometry->getVertices().getIds()){
 				geometry->modifyVertex(newcoordinates[id], id);
 			}
-
+#if MIMMO_ENABLE_MPI
+			geometry->cleanAllParallelSync();
+			geometry->updatePointGhostExchangeInfo();
+#endif
 		}
 	} // end loop on smoothing step
 

--- a/src/iogeneric/IOWavefrontOBJ.cpp
+++ b/src/iogeneric/IOWavefrontOBJ.cpp
@@ -771,6 +771,11 @@ void   ManipulateWFOBJData::execute(){
     computeNormals();
     extractPinnedLists();
 
+#if MIMMO_ENABLE_MPI
+    getGeometry()->cleanAllParallelSync();
+    getGeometry()->updatePointGhostExchangeInfo();
+#endif
+
 }
 
 /*!

--- a/src/iogeneric/MimmoGeometry.cpp
+++ b/src/iogeneric/MimmoGeometry.cpp
@@ -519,12 +519,8 @@ MimmoGeometry::write(){
         for(const auto & touple : pidsMap){
             mpp[touple.first] = touple.second;
         }
-#if MIMMO_ENABLE_MPI
-        std::string name = (m_winfo.fdir+"/"+m_winfo.fname+"."+std::to_string(m_rank)+".stl");
-#else
         std::string name = (m_winfo.fdir+"/"+m_winfo.fname+".stl");
-#endif
-        dynamic_cast<bitpit::SurfUnstructured*>(getGeometry()->getPatch())->exportSTL(name, m_codex, m_multiSolidSTL, false, &mpp);
+        dynamic_cast<bitpit::SurfUnstructured*>(getGeometry()->getPatch())->exportSTL(name, m_codex, m_multiSolidSTL, &mpp);
         return true;
     }
     break;

--- a/src/iogeneric/MimmoGeometry.cpp
+++ b/src/iogeneric/MimmoGeometry.cpp
@@ -557,7 +557,7 @@ MimmoGeometry::write(){
         // same for PID: if 0 exists, pids are incremented by 1; if -1 exists are incremented by 2;
         // Beware if id >= 10^8 nas format does not support it.
     {
-        liimap mapDataInv;
+        lilimap mapDataInv;
         dvecarr3E    points = getGeometry()->getVerticesCoords();
         livector1D   pointsID;
         pointsID.reserve(points.size());

--- a/src/manipulators/Apply.cpp
+++ b/src/manipulators/Apply.cpp
@@ -292,9 +292,9 @@ Apply::execute(){
         //no need to shrink cellAnnotation.
     }
 
-
 #if MIMMO_ENABLE_MPI
-	getGeometry()->updatePointGhostExchangeInfo();
+    getGeometry()->cleanAllParallelSync();
+    getGeometry()->updatePointGhostExchangeInfo();
 #endif
 
 };

--- a/src/parallel/Partition.cpp
+++ b/src/parallel/Partition.cpp
@@ -186,7 +186,7 @@ Partition::execute(){
 	}
 
 	if (m_nprocs>1){
-		if ((m_mode == PartitionMethod::PARTGEOM && !(getGeometry()->getPatch()->isPartitioned())) || (m_mode == PartitionMethod::SERIALIZE && (getGeometry()->getPatch()->isPartitioned())))
+		if ((m_mode == PartitionMethod::PARTGEOM && !(getGeometry()->isPartitioned())) || (m_mode == PartitionMethod::SERIALIZE && (getGeometry()->isPartitioned())))
 		{
 
 			if (!getGeometry()->areAdjacenciesBuilt()){
@@ -298,7 +298,7 @@ Partition::computePartition(){
 void
 Partition::parmetisPartGeom(){
 
-	if ((m_nprocs>1) && !(getGeometry()->getPatch()->isPartitioned())){
+	if ((m_nprocs>1) && !(getGeometry()->isPartitioned())){
 
 		lilimap mapcell = getGeometry()->getMapCell();
 		lilimap mapcellinv = getGeometry()->getMapCellInv();
@@ -379,7 +379,7 @@ Partition::serialPartition(){
 		getGeometry()->getPatch()->setCommunicator(m_communicator);
 	}
 
-	if ((m_nprocs>1) && (getGeometry()->getPatch()->isPartitioned())){
+	if ((m_nprocs>1) && (getGeometry()->isPartitioned())){
 		//Build partition to send to zero
 		long ncells = getGeometry()->getPatch()->getInternalCount();
 		m_partition.clear();
@@ -400,7 +400,7 @@ Partition::computeBoundaryPartition()
 {
 
 	if (m_mode == PartitionMethod::SERIALIZE){
-		if ((m_nprocs>1) && getBoundaryGeometry()->getPatch()->isPartitioned()){
+		if ((m_nprocs>1) && getBoundaryGeometry()->isPartitioned()){
 			//Build partition to send to zero
 			long ncells = getBoundaryGeometry()->getPatch()->getInternalCount();
 			m_boundarypartition.clear();
@@ -412,7 +412,7 @@ Partition::computeBoundaryPartition()
 	}
 	else{
 
-		if ((m_nprocs>1) && !(getBoundaryGeometry()->getPatch()->isPartitioned())){
+		if ((m_nprocs>1) && !(getBoundaryGeometry()->isPartitioned())){
 
 //			if (!getGeometry()->areInterfacesBuilt()){
 //				m_interfacesReset = true;

--- a/src/parallel/Partition.cpp
+++ b/src/parallel/Partition.cpp
@@ -300,8 +300,8 @@ Partition::parmetisPartGeom(){
 
 	if ((m_nprocs>1) && !(getGeometry()->getPatch()->isPartitioned())){
 
-		liimap mapcell = getGeometry()->getMapCell();
-		liimap mapcellinv = getGeometry()->getMapCellInv();
+		lilimap mapcell = getGeometry()->getMapCell();
+		lilimap mapcellinv = getGeometry()->getMapCellInv();
 
 		if (m_rank == 0){
 

--- a/src/parallel/Partition.cpp
+++ b/src/parallel/Partition.cpp
@@ -425,7 +425,7 @@ Partition::computeBoundaryPartition()
 				getBoundaryGeometry()->buildSkdTree();
                 bitpit::PatchSkdTree *btree = getBoundaryGeometry()->getSkdTree();
 				double tol = 1.0E-12;
-                std::vector<double> distances(getBoundaryGeometry()->getNCells(), 1.0E+18);
+                std::vector<double> distances(getBoundaryGeometry()->getNCells(), std::numeric_limits<double>::max());
 //                bitpit::PiercedVector<bitpit::Interface> & interfaces = getGeometry()->getInterfaces();
 //                for (bitpit::Interface &inter : interfaces ){
 //					if (inter.isBorder()){

--- a/src/propagators/PropagateField.cpp
+++ b/src/propagators/PropagateField.cpp
@@ -264,7 +264,7 @@ PropagateScalarField::execute(){
     //allocate the solver;
     m_solver = std::unique_ptr<bitpit::SystemSolver>(new bitpit::SystemSolver(m_print));
     //get this inverse map -> you will need it to compact the stencils.
-    liimap dataInv;
+    lilimap dataInv;
 
     //check if damping or narrow band control are active,
     //initialize their reference surfaces and compute them
@@ -333,7 +333,7 @@ PropagateScalarField::execute(){
 
     dataInv.clear();
     //reconstruct getting the direct node map -> you will need it uncompact the system solution in global id.
-    liimap mapdata = geo->getMapData(true);
+    lilimap mapdata = geo->getMapData(true);
     reconstructResults(result, mapdata);
     // now data are direcly pushed in m_field.
 
@@ -824,7 +824,7 @@ void PropagateVectorField::propagateMaskMovingPoints(livector1D & vertexList) {
 void
 PropagateVectorField::assignBCAndEvaluateRHS(std::size_t comp, bool slipCorrect,
                                             GraphLaplStencil::MPVStencil * borderLaplacianStencil,
-                                            const liimap & maplocals, dvector1D & rhs)
+                                            const lilimap & maplocals, dvector1D & rhs)
 {
 
     //resize rhs to the number of internal cells
@@ -1144,7 +1144,7 @@ PropagateVectorField::execute(){
     m_solver = std::unique_ptr<bitpit::SystemSolver>(new bitpit::SystemSolver(m_print));
 
     //declare inverse and direct map
-    liimap dataInv, data;
+    lilimap dataInv, data;
 
     //check if damping or narrow band control are active,
     //initialize their reference surfaces and compute them

--- a/src/propagators/PropagateField.cpp
+++ b/src/propagators/PropagateField.cpp
@@ -709,6 +709,10 @@ PropagateVectorField::apply(){
     for (auto it= verts.begin(); it != verts.end(); ++it){
         target->modifyVertex( it->getCoords() + m_field.at(it.getId()), it.getId() );
     }
+#if MIMMO_ENABLE_MPI
+    target->cleanAllParallelSync();
+    target->updatePointGhostExchangeInfo();
+#endif
 
     dmpvecarr3E serialized_bf;
 
@@ -720,6 +724,10 @@ PropagateVectorField::apply(){
         for(auto it= m_dampingUniSurface->getPatch()->vertexBegin(); it!= m_dampingUniSurface->getPatch()->vertexEnd(); ++it){
             m_dampingUniSurface->modifyVertex(it->getCoords() + serialized_bf.at(it.getId()), it.getId());
         }
+#if MIMMO_ENABLE_MPI
+        m_dampingUniSurface->cleanAllParallelSync();
+        m_dampingUniSurface->updatePointGhostExchangeInfo();
+#endif
     }
 
     //Check the narrowband and deform m_bandUniSurface
@@ -729,6 +737,10 @@ PropagateVectorField::apply(){
         for(auto it= m_bandUniSurface->getPatch()->vertexBegin(); it!= m_bandUniSurface->getPatch()->vertexEnd(); ++it){
             m_bandUniSurface->modifyVertex(it->getCoords() + serialized_bf.at(it.getId()), it.getId());
         }
+#if MIMMO_ENABLE_MPI
+        m_bandUniSurface->cleanAllParallelSync();
+        m_bandUniSurface->updatePointGhostExchangeInfo();
+#endif
     }
 }
 /*!
@@ -748,6 +760,10 @@ PropagateVectorField::restoreGeometry(bitpit::PiercedVector<bitpit::Vertex> & ve
         m_field.at(ID) = currentmesh.at(ID).getCoords() - coords;
         target->modifyVertex(coords, ID);
     }
+#if MIMMO_ENABLE_MPI
+    target->cleanAllParallelSync();
+    target->updatePointGhostExchangeInfo();
+#endif
 
     //damping and narrowband if active have their UniSurface morphed.
     //But since the UniSurfaces are not inputs, but internal temp resources, I see no utility

--- a/src/propagators/PropagateField.hpp
+++ b/src/propagators/PropagateField.hpp
@@ -204,14 +204,14 @@ protected:
     virtual void modifyStencilsForNarrowBand(GraphLaplStencil::MPVStencilUPtr &laplaceStencils );
 
     // Laplace Solver
-    virtual void initializeLaplaceSolver(GraphLaplStencil::MPVStencil * laplacianStencils, const liimap & maplocals);
-    virtual void updateLaplaceSolver(GraphLaplStencil::MPVStencil * laplacianStencils, const liimap & maplocals);
+    virtual void initializeLaplaceSolver(GraphLaplStencil::MPVStencil * laplacianStencils, const lilimap & maplocals);
+    virtual void updateLaplaceSolver(GraphLaplStencil::MPVStencil * laplacianStencils, const lilimap & maplocals);
     virtual void assignBCAndEvaluateRHS(std::size_t comp, bool unused, GraphLaplStencil::MPVStencil * borderLaplacianStencil,
-                                        const liimap & maplocals, dvector1D & rhs);
+                                        const lilimap & maplocals, dvector1D & rhs);
     virtual void solveLaplace(const dvector1D &rhs, dvector1D & result);
 
     // reconstruct final result field
-    virtual void reconstructResults(const dvector2D & results, const liimap & mapglobals,  livector1D * markedcells = nullptr);
+    virtual void reconstructResults(const dvector2D & results, const lilimap & mapglobals,  livector1D * markedcells = nullptr);
 
 #if MIMMO_ENABLE_MPI
     int createGhostCommunicator(MimmoObject * refgeo, bool continuous);
@@ -495,7 +495,7 @@ protected:
 
     virtual void assignBCAndEvaluateRHS(std::size_t comp, bool slipCorrect,
                                 GraphLaplStencil::MPVStencil * borderLaplacianStencil,
-                                const liimap & maplocals,
+                                const lilimap & maplocals,
                                 dvector1D & rhs);
 
     virtual void computeSlipBCCorrector(const MimmoPiercedVector<std::array<double,3> > & guessSolutionOnPoint);

--- a/src/propagators/PropagateField.tpp
+++ b/src/propagators/PropagateField.tpp
@@ -1025,7 +1025,7 @@ PropagateField<NCOMP>::updateNarrowBand(){
  */
 template<std::size_t NCOMP>
 void
-PropagateField<NCOMP>::initializeLaplaceSolver(GraphLaplStencil::MPVStencil * laplacianStencils, const liimap & maplocals){
+PropagateField<NCOMP>::initializeLaplaceSolver(GraphLaplStencil::MPVStencil * laplacianStencils, const lilimap & maplocals){
 
 	bitpit::KSPOptions &solverOptions = m_solver->getKSPOptions();
 
@@ -1091,7 +1091,7 @@ PropagateField<NCOMP>::initializeLaplaceSolver(GraphLaplStencil::MPVStencil * la
  */
 template<std::size_t NCOMP>
 void
-PropagateField<NCOMP>::updateLaplaceSolver(FVolStencil::MPVDivergence * laplacianStencils, const liimap & maplocals){
+PropagateField<NCOMP>::updateLaplaceSolver(FVolStencil::MPVDivergence * laplacianStencils, const lilimap & maplocals){
 
 	// total number of local DOFS, determines size of matrix
 	long nDOFs = m_solver->getColCount();
@@ -1154,7 +1154,7 @@ template<std::size_t NCOMP>
 void
 PropagateField<NCOMP>::assignBCAndEvaluateRHS(std::size_t comp, bool unused,
                                               GraphLaplStencil::MPVStencil * borderLaplacianStencil,
-                                              const liimap & maplocals, dvector1D & rhs)
+                                              const lilimap & maplocals, dvector1D & rhs)
 {
     BITPIT_UNUSED(unused);
     //resize rhs to the number of internal cells
@@ -1242,7 +1242,7 @@ PropagateField<NCOMP>::solveLaplace(const dvector1D &rhs, dvector1D &result){
  */
 template<std::size_t NCOMP>
 void
-PropagateField<NCOMP>::reconstructResults(const dvector2D & results, const liimap & mapglobals, livector1D * marked)
+PropagateField<NCOMP>::reconstructResults(const dvector2D & results, const lilimap & mapglobals, livector1D * marked)
 {
     if(results.size() != NCOMP){
         (*m_log) << "WARNING in "<<m_name<<" . A field with dimension different from" <<NCOMP<<" is feeded to reconstructResults. m_field is not touched"<<std::endl;

--- a/src/propagators/PropagateField.tpp
+++ b/src/propagators/PropagateField.tpp
@@ -1356,7 +1356,7 @@ PropagateField<NCOMP>::communicateGhostData(MimmoPiercedVector<std::array<double
         throw std::runtime_error("Propagate Class ::communicateGhostData no ref Geometry in mpv data!");
     }
     //if geo is not partitioned you have nothing to communicate.
-    if (!geo->getPatch()->isPartitioned()) return;
+    if (!geo->isPartitioned()) return;
 
     //check for communicator on geometry, if not exists create it
     m_ghostTags[geo] = createGhostCommunicator(geo, true);
@@ -1393,7 +1393,7 @@ PropagateField<NCOMP>::communicatePointGhostData(MimmoPiercedVector<std::array<d
         throw std::runtime_error("Propagate Class ::communicatePointGhostData no ref Geometry in mpv data!");
     }
     //if geo is not partitioned you have nothing to communicate.
-    if (!geo->getPatch()->isPartitioned()) return;
+    if (!geo->isPartitioned()) return;
 
     //check for communicator on geometry, if not exists create it
     m_pointGhostTags[geo] = createPointGhostCommunicator(geo, true);

--- a/src/propagators/PropagateField.tpp
+++ b/src/propagators/PropagateField.tpp
@@ -1000,16 +1000,16 @@ PropagateField<NCOMP>::updateNarrowBand(){
         double correction_new = 0.0;
         //the last one is the point idT itself carrying the complement weight.
         for (std::size_t i=0; i<size-1; ++i){
-            long &idL = loc_stencil.rawGetPattern(i);
+            long &idL = loc_stencil.patternData()[i];
             if(!m_banddistances.exists(idL))         continue;
             if(m_banddistances.at(idL) > localdist ){
-                correction_old += loc_stencil.rawGetWeight(i);
-                loc_stencil.rawGetWeight(i) *= m_bandrelax; // use here the band relaxation factor.
-                correction_new += loc_stencil.rawGetWeight(i);
+                correction_old += loc_stencil.weightData()[i];
+                loc_stencil.weightData()[i] *= m_bandrelax; // use here the band relaxation factor.
+                correction_new += loc_stencil.weightData()[i];
             }
 
         }
-        loc_stencil.rawGetWeight(size-1) += (correction_old - correction_new); //(-sum(w_i) + sum(w_excluded) - sum_recalc );
+        loc_stencil.weightData()[size-1] += (correction_old - correction_new); //(-sum(w_i) + sum(w_excluded) - sum_recalc );
     }
 }
 

--- a/src/propagators/StencilFunctions.cpp
+++ b/src/propagators/StencilFunctions.cpp
@@ -183,7 +183,6 @@ MPVGradientUPtr   computeFVCellGradientStencil(MimmoSharedPointer<MimmoObject> g
         }
 
         it->addComplementToZero(cellID); // adding the central node weight as minus sum of other weights.
-        it->flatten();
 
     }
     return result;
@@ -345,16 +344,13 @@ MPVGradientUPtr   updateFVFaceGradientStencil(MimmoSharedPointer<MimmoObject> ge
             //xxxCentroid.
             ownerProjStencil.appendItem(ownerID, 1.0);
             ownerProjStencil += dotProduct(ownerStencil, ownerProjection-ownerCentroid);
-            ownerProjStencil.flatten();
 
             neighProjStencil.appendItem(neighID, 1.0);
             neighProjStencil += dotProduct(neighStencil, neighProjection-neighCentroid);
-            neighProjStencil.flatten();
 
             //calculate stencil @ interface as the plain average of owner and neigh ccell
             // gradient stencil
             avgStencil = 0.5*(ownerStencil + neighStencil);
-            avgStencil.flatten();
             // push it in MPV.
             auto it = result->insert(interfid, avgStencil);
 
@@ -655,7 +651,6 @@ MPVStencilUPtr computeLaplacianStencils(MimmoSharedPointer<MimmoObject> geo, dou
     	if (geo->isPointInterior(id))
     	{
     		result->at(id).addComplementToZero(id); // adding the central node weight as minus sum of other weights.
-    		result->at(id).flatten();
     	}
     }
 
@@ -742,7 +737,6 @@ MPVStencilUPtr computeLaplacianStencils(MimmoSharedPointer<MimmoObject> geo, std
     	if (geo->isPointInterior(id))
     	{
     		result->at(id).addComplementToZero(id); // adding the central node weight as minus sum of other weights.
-    		result->at(id).flatten();
     	}
     }
 

--- a/src/utils/ControlDeformExtSurface.cpp
+++ b/src/utils/ControlDeformExtSurface.cpp
@@ -120,7 +120,7 @@ ControlDeformExtSurface::buildPorts(){
 double
 ControlDeformExtSurface::getViolation(){
 
-    double result = -1.0E+18;
+    double result = -1.0*std::numeric_limits<double>::max();
     for(const auto & val : m_violationField){
         result = std::fmax(result, val);
     }
@@ -315,7 +315,7 @@ ControlDeformExtSurface::execute(){
     long int ID;
     for (const auto & v : geo->getVertices()){
         ID = v.getId();
-        m_violationField.insert(ID, -1.0e+18);
+        m_violationField.insert(ID, -1.0*std::numeric_limits<double>::max());
     }
 
     dvector1D violationField;
@@ -738,7 +738,7 @@ ControlDeformExtSurface::extractInfo(std::string file){
 double
 ControlDeformExtSurface::evaluateSignedDistance(darray3E &point, mimmo::MimmoObject * geo, long & id, darray3E & normal, double &initRadius){
 
-    double dist = 1.0E+18;
+    double dist = std::numeric_limits<double>::max();
     double rate = 0.02;
     int kmax = 1000;
     int kiter = 0;
@@ -748,8 +748,10 @@ ControlDeformExtSurface::evaluateSignedDistance(darray3E &point, mimmo::MimmoObj
 
     while(flag && kiter < kmax){
         dist = skdTreeUtils::signedDistance(&point, geo->getSkdTree(), id, normal, initRadius);
-        flag = (dist == 1.0E+18);
-        if(flag)    initRadius *= (1.0+ rate*((double)flag));
+        flag = (dist == std::numeric_limits<double>::max());
+        if(flag){
+            initRadius *= (1.0 + rate);
+        }
         kiter++;
     }
 

--- a/src/utils/ControlDeformMaxDistance.cpp
+++ b/src/utils/ControlDeformMaxDistance.cpp
@@ -113,7 +113,7 @@ ControlDeformMaxDistance::buildPorts(){
 double
 ControlDeformMaxDistance::getViolation(){
 
-    double result = -1.0E+18;
+    double result = -1.0*std::numeric_limits<double>::max();
     for(const auto & val : m_violationField){
         result = std::fmax(result, val);
     }
@@ -206,7 +206,7 @@ ControlDeformMaxDistance::execute(){
         ID = v.getId();
         points.insert(ID, geo->getVertexCoords(ID) + m_defField[ID] );
         normDef.insert(ID, norm2(m_defField[ID]));
-        m_violationField.insert(ID, -1.0e+18);
+        m_violationField.insert(ID, -1.0*std::numeric_limits<double>::max());
     }
 
     double dist;
@@ -217,14 +217,16 @@ ControlDeformMaxDistance::execute(){
     bool flag;
     long int IDC;
     for(const auto &ID : points.getIds()){
-        dist =1.0E+18;
+        dist = std::numeric_limits<double>::max();
         kiter = 0;
         flag = true;
         radius = std::fmax(1.0E-8, normDef[ID]);
         while(flag && kiter < kmax){
             dist = skdTreeUtils::distance(&points[ID], geo->getSkdTree(), IDC, radius);
-            flag = (dist == 1.0E+18);
-            if(flag)    radius *= (1.0+ rate*((double)flag));
+            flag = (dist == std::numeric_limits<double>::max());
+            if(flag){
+                radius *= (1.0 + rate);
+            }
             kiter++;
         }
         if(kiter == kmax)    dist = m_maxDist - dist;

--- a/src/utils/CreateSeedsOnSurface.cpp
+++ b/src/utils/CreateSeedsOnSurface.cpp
@@ -1414,7 +1414,7 @@ double
 CreateSeedsOnSurface::interpolateSensitivity(darray3E & point){
 
     MimmoSharedPointer<MimmoObject> geo = getGeometry();
-    long supportCell = skdTreeUtils::locatePointOnPatch(point, *(geo->getSkdTree()));
+    long supportCell = skdTreeUtils::locatePointOnPatch(point, geo->getSkdTree());
     if(supportCell == bitpit::Cell::NULL_ID)    return 0.0;
 
     bitpit::Cell & cell = geo->getPatch()->getCell(supportCell);

--- a/src/utils/CreateSeedsOnSurface.cpp
+++ b/src/utils/CreateSeedsOnSurface.cpp
@@ -498,7 +498,7 @@ CreateSeedsOnSurface::solveLSet(bool debug){
 
         dmpvector1D field;
         for (const auto & v : tri->getVertices()){
-            field.insert(v.getId(), 1.0E+18);
+            field.insert(v.getId(), std::numeric_limits<double>::max());
         }
         for(const auto & dd : m_deads)    field[dd] = 0.0;
 
@@ -912,7 +912,7 @@ CreateSeedsOnSurface::updateEikonal(double g, double s, long tVert,long tCell, b
     int                        k, m;
 
     int                        select = -1;
-    double                    value(1.0e+18);
+    double                    value(std::numeric_limits<double>::max());
     double                    dVU, dVW, dWU, dVP;
     std::array<double,3>    eVU, eVW, eWU, eVP, P;
 
@@ -1074,7 +1074,7 @@ CreateSeedsOnSurface::updateEikonal(double g, double s, long tVert,long tCell, b
 /*!
  * Solve the 3D Eikonal equation |grad(u)| = g, using  a fast marching method, on a target triangulation
  * associated unstructured superficial grid. Tessellation must be mandatorily a triangular one.
- * (SurfaceConstraints::m_sdf values in the unknown region must be set to the value 1.0e+18.
+ * (SurfaceConstraints::m_sdf values in the unknown region must be set to the value std::numeric_limits<double>::max().
  *  Dead vertices of front to be propagated must be set to zero, initially)
  * \param[in] g Propagation speed.
  * \param[in] s Velocity sign (+1 --> propagate outwards, -1 --> propagate inwards).
@@ -1127,7 +1127,7 @@ CreateSeedsOnSurface::solveEikonal(double g, double s,bitpit::PatchKernel &tri, 
                 itend = neighs.end();
                 while(!check && it !=itend){
 
-                    check = s*field[*it] >= 0.0 && field[*it] < 1.0E+18;
+                    check = s*field[*it] >= 0.0 && field[*it] < std::numeric_limits<double>::max();
                     ++it;
                 };
 

--- a/src/utils/Proj3DCurveOnSurface.cpp
+++ b/src/utils/Proj3DCurveOnSurface.cpp
@@ -352,7 +352,7 @@ int
 Proj3DCurveOnSurface::fillPreliminaryStructure(dvecarr3E & points, std::unordered_map<long, std::array<long,2> > &connectivity){
     int nVerts, nCells, res;
     long id;
-    liimap mapDataInv;
+    lilimap mapDataInv;
     if (m_cobj) {
         nVerts = m_cobj->getNVertices();
         mapDataInv = m_cobj->getMapDataInv();

--- a/src/utils/Proj3DCurveOnSurface.cpp
+++ b/src/utils/Proj3DCurveOnSurface.cpp
@@ -307,12 +307,17 @@ Proj3DCurveOnSurface::projection(){
 
     //...and projecting them onto target surface
     if(!getGeometry()->isSkdTreeSync())    getGeometry()->buildSkdTree();
-    int counter=0;
-    dvecarr3E projs(points.size());
-    for(auto &val : points){
-        projs[counter]= skdTreeUtils::projectPoint(&val, getGeometry()->getSkdTree());
-        ++counter;
-    }
+    std::size_t npoints = points.size();
+    dvecarr3E projs(npoints);
+    livector1D ids(npoints);
+#if MIMMO_ENABLE_MPI
+    ivector1D ranks(npoints);
+    double radius =  std::numeric_limits<double>::max();
+    bool shared = true;
+    skdTreeUtils::projectPointGlobal(npoints, points.data(), getGeometry()->getSkdTree(), projs.data(), ids.data(), ranks.data(), radius, shared);
+#else
+    skdTreeUtils::projectPoint(npoints, points.data(), getGeometry()->getSkdTree(), projs.data(), ids.data());
+#endif
 
     dum->getPatch()->reserveVertices(points.size());
     dum->getPatch()->reserveCells(connectivity.size());

--- a/src/utils/ProjectCloud.cpp
+++ b/src/utils/ProjectCloud.cpp
@@ -242,12 +242,18 @@ ProjectCloud::execute(){
     if(!getGeometry()->isSkdTreeSync())    getGeometry()->buildSkdTree();
 
     //project points on surface.
-    int counter = 0;
-    m_proj.resize(m_points.size(), {{0.0,0.0,0.0}});
-    for(darray3E &val : m_points){
-        m_proj[counter]= skdTreeUtils::projectPoint(&val, getGeometry()->getSkdTree());
-        ++counter;
-    }
+    std::size_t npoints = m_points.size();
+    dvecarr3E projs(npoints);
+    livector1D ids(npoints);
+#if MIMMO_ENABLE_MPI
+    ivector1D ranks(npoints);
+    double radius =  std::numeric_limits<double>::max();
+    bool shared = true;
+    skdTreeUtils::projectPointGlobal(npoints, m_points.data(), getGeometry()->getSkdTree(), projs.data(), ids.data(), ranks.data(), radius, shared);
+#else
+    skdTreeUtils::projectPoint(npoints, m_points.data(), getGeometry()->getSkdTree(), projs.data(), ids.data());
+#endif
+
     return;
 };
 

--- a/src/utils/SpecularPoints.cpp
+++ b/src/utils/SpecularPoints.cpp
@@ -413,12 +413,18 @@ SpecularPoints::execute(){
     if(project){
         if(!getGeometry()->isSkdTreeSync())    getGeometry()->buildSkdTree();
 
-        //project points on surface.
-        int counter = 0;
-        for(auto &val : m_proj){
-            m_proj[counter]= skdTreeUtils::projectPoint(&val, getGeometry()->getSkdTree());
-            ++counter;
-        }
+        // In place use of project point
+        std::size_t npoints = m_proj.size();
+        livector1D ids(npoints);
+    #if MIMMO_ENABLE_MPI
+        ivector1D ranks(npoints);
+        double radius =  std::numeric_limits<double>::max();
+        bool shared = true;
+        skdTreeUtils::projectPointGlobal(npoints, m_proj.data(), getGeometry()->getSkdTree(), m_proj.data(), ids.data(), ranks.data(), radius, shared);
+    #else
+        skdTreeUtils::projectPoint(npoints, m_proj.data(), getGeometry()->getSkdTree(), m_proj.data(), ids.data());
+    #endif
+
     }
 };
 

--- a/test/parallel/CMakeLists.txt
+++ b/test/parallel/CMakeLists.txt
@@ -1,0 +1,46 @@
+#---------------------------------------------------------------------------
+#
+#  mimmo
+#
+#  Copyright (C) 2015-2017 OPTIMAD engineering Srl
+#
+#  -------------------------------------------------------------------------
+#  License
+#  This file is part of mimmo.
+#
+#  mimmo is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License v3 (LGPL)
+#  as published by the Free Software Foundation.
+#
+#  mimmo is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+#  License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public License
+#  along with mimmo. If not, see <http://www.gnu.org/licenses/>.
+#
+#---------------------------------------------------------------------------*/
+
+# Specify the version being used as well as the language
+cmake_minimum_required(VERSION 2.8)
+
+# Name of the current module
+get_filename_component(MODULE_NAME ${CMAKE_CURRENT_LIST_DIR} NAME)
+
+# List of tests
+set(TESTS "")
+list(APPEND TESTS "test_parallel_00000:2")
+list(APPEND TESTS "test_parallel_00001:2")
+
+# Test extra libraries
+set(TEST_EXTRA_LIBRARIES "")
+
+# Add tests
+addModuleTests(${MODULE_NAME} "${TESTS}" "${TEST_EXTRA_LIBRARIES}")
+unset(TESTS)
+
+# add_custom_command(
+#     TARGET "name test in the list" PRE_BUILD
+#     COMMAND ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_CURRENT_SOURCE_DIR}/data/xxx" "${CMAKE_CURRENT_BINARY_DIR}/data/xxx"
+#     )

--- a/test/parallel/test_parallel_00000.cpp
+++ b/test/parallel/test_parallel_00000.cpp
@@ -1,0 +1,212 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  mimmo
+ *
+ *  Copyright (C) 2015-2017 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of mimmo.
+ *
+ *  mimmo is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  mimmo is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with mimmo. If not, see <http://www.gnu.org/licenses/>.
+ *
+ \ *---------------------------------------------------------------------------*/
+
+#include "mimmo_core.hpp"
+#include "SkdTreeUtils.hpp"
+#include "Partition.hpp"
+#include <exception>
+using namespace std;
+using namespace bitpit;
+using namespace mimmo;
+
+
+/*
+ * Creating surface triangular mesh and return it in a MimmoObject.
+ * \param[in,out] mesh pointer to a MimmoObject mesh to fill.
+ * \return true if successfully created mesh
+ */
+bool createMimmoMesh(MimmoObject * mesh){
+
+    if (mesh->getRank() == 0){
+        double dx = 0.25, dy = 0.25;
+        int nV, nC;
+        //create vertexlist
+        dvecarr3E vertex(35,{{0.0,0.0,0.0}});
+        livector2D conn(48, livector1D(3));
+
+        for(int i=0; i<7; ++i){
+            for(int j=0; j<5; j++){
+                nV = 5*i + j;
+                vertex[nV][0] = i*dx;
+                vertex[nV][1] = j*dy;
+            }
+        }
+
+        for(int j=0; j<4; ++j){
+            for(int i=0; i<3; ++i){
+                nC = 8*i + 2*j;
+
+                conn[nC][0] = 5*i + j;
+                conn[nC][1] = 5*(i+1) + j;
+                conn[nC][2] = 5*i + j+1;
+
+                conn[nC+1][0] = 5*(i+1) + j;
+                conn[nC+1][1] = 5*(i+1) + j+1;
+                conn[nC+1][2] = 5*i + j+1;
+            }
+        }
+
+        for(int j=0; j<4; ++j){
+            for(int i=3; i<6; ++i){
+                nC = 8*i + 2*j;
+
+                conn[nC][0] = 5*i + j;
+                conn[nC][1] = 5*(i+1) + j;
+                conn[nC][2] = 5*(i+1) + j+1;
+
+                conn[nC+1][0] = 5*i + j;
+                conn[nC+1][1] = 5*(i+1) + j+1;
+                conn[nC+1][2] = 5*i + j+1;
+            }
+        }
+
+        mesh->getVertices().reserve(35);
+        mesh->getCells().reserve(48);
+
+        //fill the mimmoObject;
+        long cV=0;
+        for(auto & val: vertex){
+            mesh->addVertex(val, cV);
+            cV++;
+        }
+
+        long cC=0;
+        bitpit::ElementType eltype = bitpit::ElementType::TRIANGLE;
+        for(auto & val: conn){
+            mesh->addConnectedCell(val, eltype, cC, mesh->getRank());
+            cC++;
+        }
+    }
+
+    mesh->buildAdjacencies();
+
+    bool check = true;
+    if (mesh->getRank() == 0){
+        check = (mesh->getNCells() == 48) && (mesh->getNVertices() == 35);
+    }
+
+    mesh->getPatch()->write("support.0");
+
+    return check;
+}
+// =================================================================================== //
+/*
+ * Test: testing project point method utility
+ */
+int test0() {
+
+    // ====================================================================== //
+    // Initialize the logger
+    // ====================================================================== //
+    int nProcs;
+    int rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &nProcs);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    log::manager().initialize(log::COMBINED, true, nProcs, rank);
+    log::cout().setVisibility(log::MASTER);
+
+    /* Create test mesh */
+    MimmoSharedPointer<MimmoObject> mimmo0(new MimmoObject());
+    if(!createMimmoMesh(mimmo0.get())) {
+        return 1;
+    }
+
+    /* Instantiation of a Partition object with default patition method space filling curve.
+     * Plot Optional results during execution active for Partition block.
+     */
+    mimmo::Partition* partition = new mimmo::Partition();
+    partition->setPlotInExecution(true);
+    partition->setGeometry(mimmo0);
+    partition->exec();
+    mimmo0->getPatch()->write("support.1");
+
+    /*Build the SkdTree of the geometry and retrieve it. */
+    mimmo0->buildSkdTree();
+    bitpit::PatchSkdTree* tree = mimmo0->getSkdTree();
+
+    /* Initialize points. */
+    bitpit::log::cout() << " --- POINTS --- " << std::endl;
+    std::size_t np = 5;
+    std::vector<std::array<double,3>> points(np);
+    for (std::size_t i = 0; i < np; i++){
+        std::array<double,3> & point = points[i];
+        double x = 1.5/double(np)*double(i);
+        double y = 1./double(np)*double(i);
+        double z = 1.;
+        point = std::array<double,3>({x, y, z});
+        bitpit::log::cout()<< point <<std::endl;
+    }
+    bitpit::log::cout() << std::endl;
+
+    /* Project points on surface. */
+    bitpit::log::cout() << " --- PROJECTED POINTS --- " << std::endl;
+    std::vector<std::array<double,3>> array_projected_points(np);
+    std::vector<long> projectCellIds(np, bitpit::Cell::NULL_ID);
+    std::vector<int> ranks(np, -1);
+    skdTreeUtils::projectPointGlobal(np, points.data(), tree, array_projected_points.data(), projectCellIds.data(), ranks.data());
+
+    for (auto & point : array_projected_points)
+        bitpit::log::cout()<< point <<std::endl;
+    bitpit::log::cout() << std::endl;
+
+
+    /* Locate points on surface patch. */
+    bitpit::log::cout() << " --- LOCATE POINTS --- " << std::endl;
+    std::vector<long> locateCellIds(np, bitpit::Cell::NULL_ID);
+    skdTreeUtils::locatePointOnGlobalPatch(np, array_projected_points.data(), tree, locateCellIds.data(), ranks.data());
+
+    for (std::size_t i = 0; i < np; i++){
+        bitpit::log::cout()<< " projected cell id : " << projectCellIds[i] << "  locate cell id : " << locateCellIds[i] <<std::endl;
+    }
+
+    bool check = true;
+    for (std::size_t i = 0; i < np; i++){
+        check = check && (std::abs(locateCellIds[i] - projectCellIds[i]) == 0);
+    }
+    bitpit::log::cout() << std::endl;
+
+
+    return int(!check);
+}
+
+// =================================================================================== //
+
+int main( int argc, char *argv[] ) {
+
+    MPI_Init(&argc, &argv);
+
+    /**<Calling mimmo Test routines*/
+    int val = 1;
+    try{
+        val = test0() ;
+    }
+    catch(std::exception & e){
+        std::cout<<"test_parallel_00000 exited with an error of type : "<<e.what()<<std::endl;
+        return 1;
+    }
+
+    MPI_Finalize();
+
+    return val;
+}

--- a/test/parallel/test_parallel_00001.cpp
+++ b/test/parallel/test_parallel_00001.cpp
@@ -1,0 +1,226 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  mimmo
+ *
+ *  Copyright (C) 2015-2017 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of mimmo.
+ *
+ *  mimmo is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  mimmo is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with mimmo. If not, see <http://www.gnu.org/licenses/>.
+ *
+ \ *---------------------------------------------------------------------------*/
+
+#include "mimmo_core.hpp"
+#include "SkdTreeUtils.hpp"
+#include "Partition.hpp"
+#include <exception>
+using namespace std;
+using namespace bitpit;
+using namespace mimmo;
+
+/*
+ * Creating surface triangular mesh and return it in a MimmoObject.
+ * \param[in,out] mesh pointer to a MimmoObject mesh to fill.
+ * \param[in] origin Origin point of the mesh.
+ * \return true if successfully created mesh
+ */
+bool createMimmoMesh(MimmoObject * mesh, std::array<double,3> origin = std::array<double,3>({0.,0.,0.})){
+
+    if (mesh->getRank() == 0){
+        double dx = 0.25, dy = 0.25;
+        int nV, nC;
+        //create vertexlist
+        dvecarr3E vertex(35,{{0.,0.,0.}});
+        livector2D conn(48, livector1D(3));
+
+        for(int i=0; i<7; ++i){
+            for(int j=0; j<5; j++){
+                nV = 5*i + j;
+                vertex[nV][0] = origin[0] + i*dx;
+                vertex[nV][1] = origin[1] + j*dy;
+                vertex[nV][2] = origin[2];
+            }
+        }
+
+        for(int j=0; j<4; ++j){
+            for(int i=0; i<3; ++i){
+                nC = 8*i + 2*j;
+
+                conn[nC][0] = 5*i + j;
+                conn[nC][1] = 5*(i+1) + j;
+                conn[nC][2] = 5*i + j+1;
+
+                conn[nC+1][0] = 5*(i+1) + j;
+                conn[nC+1][1] = 5*(i+1) + j+1;
+                conn[nC+1][2] = 5*i + j+1;
+            }
+        }
+
+        for(int j=0; j<4; ++j){
+            for(int i=3; i<6; ++i){
+                nC = 8*i + 2*j;
+
+                conn[nC][0] = 5*i + j;
+                conn[nC][1] = 5*(i+1) + j;
+                conn[nC][2] = 5*(i+1) + j+1;
+
+                conn[nC+1][0] = 5*i + j;
+                conn[nC+1][1] = 5*(i+1) + j+1;
+                conn[nC+1][2] = 5*i + j+1;
+            }
+        }
+
+        mesh->getVertices().reserve(35);
+        mesh->getCells().reserve(48);
+
+        //fill the mimmoObject;
+        long cV=0;
+        for(auto & val: vertex){
+            mesh->addVertex(val, cV);
+            cV++;
+        }
+
+        long cC=0;
+        bitpit::ElementType eltype = bitpit::ElementType::TRIANGLE;
+        for(auto & val: conn){
+            mesh->addConnectedCell(val, eltype, cC, mesh->getRank());
+            cC++;
+        }
+    }
+
+    mesh->buildAdjacencies();
+
+    bool check = true;
+    if (mesh->getRank() == 0){
+        check = (mesh->getNCells() == 48) && (mesh->getNVertices() == 35);
+    }
+
+    return check;
+}
+// =================================================================================== //
+/*
+ * Test: testing project point method utility
+ */
+int test1() {
+
+    // ====================================================================== //
+    // Initialize the logger
+    // ====================================================================== //
+    int nProcs;
+    int rank;
+    MPI_Comm_size(MPI_COMM_WORLD, &nProcs);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    log::manager().initialize(log::COMBINED, true, nProcs, rank);
+    log::cout().setVisibility(log::MASTER);
+
+    /* Create target test mesh */
+    MimmoSharedPointer<MimmoObject> target(new MimmoObject());
+    if(!createMimmoMesh(target.get())) {
+        return 1;
+    }
+
+    /* Instantiation of a Partition object with default patition method space filling curve.
+     * Plot Optional results during execution active for Partition block.
+     */
+    mimmo::Partition* partitionTarget = new mimmo::Partition();
+    partitionTarget->setPlotInExecution(true);
+    partitionTarget->setGeometry(target);
+    partitionTarget->exec();
+    target->getPatch()->write("target");
+
+    /*Build the SkdTree of the geometry and retrieve it. */
+    target->buildSkdTree();
+    bitpit::PatchSkdTree* treeTarget = target->getSkdTree();
+
+
+    /* Create selection mesh */
+    MimmoSharedPointer<MimmoObject> selection(new MimmoObject());
+    std::array<double,3> origin({0.6, 0.6, 0.01});
+    if(!createMimmoMesh(selection.get(), origin)) {
+        return 1;
+    }
+
+    /* Instantiation of a Partition object with default patition method space filling curve.
+     * Plot Optional results during execution active for Partition block.
+     */
+    mimmo::Partition* partitionSelection = new mimmo::Partition();
+    partitionSelection->setPlotInExecution(true);
+    partitionSelection->setGeometry(selection);
+    partitionSelection->exec();
+    selection->getPatch()->write("selection");
+
+    /*Build the SkdTree of the geometry and retrieve it. */
+    selection->buildSkdTree();
+    bitpit::PatchSkdTree* treeSelection = selection->getSkdTree();
+
+    /* Select by Patch. */
+    std::vector<long> selectedCells;
+    selectedCells = skdTreeUtils::selectByGlobalPatch(treeSelection, treeTarget, 2.0e-02);
+
+    std::cout << " --- Selected cells --- " << std::endl;
+    std::cout << "#" << rank << " selected cell size : " << selectedCells.size() << std::endl;
+    for (long cell : selectedCells){
+        std::cout << "#" << rank << " selected cell id : " << cell << std::endl;
+    }
+    std::cout << std::endl;
+
+    bool check = true;
+    std::set<long> result;
+    result.insert(20);
+    result.insert(21);
+    result.insert(22);
+    result.insert(23);
+    result.insert(28);
+    result.insert(29);
+    result.insert(30);
+    result.insert(31);
+    result.insert(36);
+    result.insert(37);
+    result.insert(38);
+    result.insert(39);
+    result.insert(44);
+    result.insert(45);
+    result.insert(46);
+    result.insert(47);
+    for (long cell : selectedCells){
+        check = check && (result.count(cell));
+    }
+
+    if (check)
+        bitpit::log::cout() << " test passed " << std::endl;
+
+    return int(!check);
+}
+
+// =================================================================================== //
+
+int main( int argc, char *argv[] ) {
+
+    MPI_Init(&argc, &argv);
+
+    /**<Calling mimmo Test routines*/
+    int val = 1;
+    try{
+        val = test1() ;
+    }
+    catch(std::exception & e){
+        std::cout<<"test_parallel_00001 exited with an error of type : "<<e.what()<<std::endl;
+        return 1;
+    }
+
+    MPI_Finalize();
+
+    return val;
+}


### PR DESCRIPTION
Update with SkdTree and export STL features of bitpit.

Major modifications:

- add parallel version of SkdTreeUtils
- fix get bounding box during parallel run
- update propagators use of stencil with bitpit class
- update MimmoGeometry export STL with parallel version of bitpit

Compiled with https://github.com/optimad/bitpit/commit/d76672a5c82f7ce301d41d10c4df3eddc84a6c9c