### PR TITLE
utils: fix ProjectCloud

### DIFF
--- a/src/utils/ProjectCloud.cpp
+++ b/src/utils/ProjectCloud.cpp
@@ -254,6 +254,7 @@ ProjectCloud::execute(){
     skdTreeUtils::projectPoint(npoints, m_points.data(), getGeometry()->getSkdTree(), projs.data(), ids.data());
 #endif
 
+    std::swap(m_proj, projs);
     return;
 };
 


### PR DESCRIPTION
missing m_proj member fill during class execution.
Every time the class executed itself, the result was empty

compliant with bitpit master https://github.com/optimad/bitpit/commit/a57f344b99b4f518dcd0c636150da3c6a301ef03