### PR TITLE
iogeneric: modify MimmoGeometry to allow derived class

### DIFF
--- a/src/iogeneric/MimmoGeometry.cpp
+++ b/src/iogeneric/MimmoGeometry.cpp
@@ -508,7 +508,12 @@ MimmoGeometry::write(){
         //action completed, reset m_refPID to zero.
         m_refPID = 0;
     }
-    //writing
+
+    //check writing filetype
+    if (!FileType::_from_integral_nothrow(m_winfo.ftype)){
+        return false;
+    }
+
     switch(FileType::_from_integral(m_winfo.ftype)){
 
     case FileType::STL :
@@ -666,6 +671,11 @@ MimmoGeometry::write(){
  */
 bool
 MimmoGeometry::read(){
+
+    //check reading filetype
+    if (!FileType::_from_integral_nothrow(m_rinfo.ftype)){
+        return false;
+    }
 
     switch(FileType::_from_integral(m_rinfo.ftype)){
 

--- a/src/iogeneric/MimmoGeometry.hpp
+++ b/src/iogeneric/MimmoGeometry.hpp
@@ -133,7 +133,7 @@ enum WFORMAT{
  */
 class MimmoGeometry: public BaseManipulation{
 
-private:
+protected:
     bool         m_read;         /**<If true it reads the geometry from file during the execution.*/
     FileDataInfo m_rinfo;       /**< Info on the external file to read */
 
@@ -226,8 +226,6 @@ protected:
     void swap(MimmoGeometry & x) noexcept;
     void        setIOMode(IOMode mode);
     void        setIOMode(int mode);
-
-private:
     void    setDefaults();
     void    _setRead(bool read = true);
     void    _setWrite(bool write = true);


### PR DESCRIPTION
This pull allows to derive blocks from MimmoGeometry class by:

- making some members protected
- checking file format enum before read/write

Compiled with https://github.com/optimad/bitpit/commit/2ae49a8e00da488411ddb36a140505d4761e6d7e