### PR TITLE
Propagators: add surface bulk mesh support in PropagateField

### DIFF
--- a/examples/parallel_example_00003.cpp
+++ b/examples/parallel_example_00003.cpp
@@ -223,7 +223,7 @@ int test00003() {
 	// Now create a PropagateScalarField and solve the laplacian.
 	mimmo::PropagateVectorField * prop = new mimmo::PropagateVectorField();
 	prop->setGeometry(partition->getGeometry());
-	prop->addDirichletBoundarySurface(partition->getBoundaryGeometry());
+	prop->addDirichletBoundaryPatch(partition->getBoundaryGeometry());
 	prop->addDirichletConditions(&bc_surf_field);
 	prop->setSolverMultiStep(10);
 	prop->setPlotInExecution(true);

--- a/src/core/MimmoPiercedVector.hpp
+++ b/src/core/MimmoPiercedVector.hpp
@@ -106,6 +106,8 @@ public:
 
     std::size_t getDataFrom(const MimmoPiercedVector<mpv_t> & other, bool strict = false);
     void squeezeOutExcept(const std::vector<long int> & list, bool keepOrder = false);
+    void squeezeOutExcept(const std::unordered_set<long int> & list, bool keepOrder = false);
+
 
 private:
     livector1D getGeometryIds(bool ordered=false);

--- a/src/core/MimmoPiercedVector.tpp
+++ b/src/core/MimmoPiercedVector.tpp
@@ -906,5 +906,39 @@ MimmoPiercedVector<mpv_t>::squeezeOutExcept(const std::vector<long int> & list, 
     }
 }
 
+/*!
+ * Erase all data not contained in the target list and squeeze the structure.
+ *
+ * \param[in] list of ids to save from cleaning
+ * \param[in] keepOrder if true keep the survivors in the same order as they appear in the original list.
+ */
+template<typename mpv_t>
+void
+MimmoPiercedVector<mpv_t>::squeezeOutExcept(const std::unordered_set<long int> & list, bool keepOrder){
+
+    if(keepOrder){
+        // erase elements in the list then squeeze the piercedvector.
+        MimmoPiercedVector<mpv_t> result (m_geometry, m_loc);
+        result.setName(m_name);
+        result.reserve(list.size());
+        for(auto it = this->begin(); it != this->end(); ++it){
+            if(list.count(it.getId()) > 0){
+                result.insert(it.getId(), *it);
+            }
+        }
+        this->swap(result);
+    }else{
+        // if the order does not matter, create a new mpv and swap with the current
+        MimmoPiercedVector<mpv_t> result (m_geometry, m_loc);
+        result.setName(m_name);
+        for(long id: list){
+            if(this->exists(id)){
+                result.insert(id, this->at(id));
+            }
+        }
+        this->swap(result);
+    }
+}
+
 
 }

--- a/src/propagators/StencilFunctions.cpp
+++ b/src/propagators/StencilFunctions.cpp
@@ -561,7 +561,7 @@ MPVDivergenceUPtr computeFVLaplacianStencil (MPVGradient & faceGradientStencil, 
     }
 
     //clean result and fit its dimension to the only cells involved
-    result->squeezeOutExcept(std::vector<long>(cellInvolved.begin(), cellInvolved.end()), true);
+    result->squeezeOutExcept(cellInvolved, true);
 
     //divide stencils by their cell volume and optimize
     for(MPVDivergence::iterator it = result->begin(); it !=result->end(); ++it){

--- a/test/propagators/test_propagators_00001.cpp
+++ b/test/propagators/test_propagators_00001.cpp
@@ -172,7 +172,7 @@ int test1() {
     mimmo::PropagateScalarField * prop = new mimmo::PropagateScalarField();
     prop->setName("test00001_PropagateScalarField");
     prop->setGeometry(mesh);
-    prop->addDirichletBoundarySurface(bdirMesh);
+    prop->addDirichletBoundaryPatch(bdirMesh);
     prop->addDirichletConditions(&bc_surf_field);
     prop->setDamping(false);
     prop->setPlotInExecution(true);
@@ -202,7 +202,7 @@ int test1() {
     mimmo::PropagateVectorField * prop3D = new mimmo::PropagateVectorField();
     prop3D->setName("test00001_PropagateVectorField");
     prop3D->setGeometry(mesh);
-    prop3D->addDirichletBoundarySurface(bdirMesh);
+    prop3D->addDirichletBoundaryPatch(bdirMesh);
     prop3D->addDirichletConditions(&bc_surf_3Dfield);
     prop3D->setDamping(true);
     prop3D->setDampingType(1);

--- a/test/propagators/test_propagators_00002.cpp
+++ b/test/propagators/test_propagators_00002.cpp
@@ -281,7 +281,7 @@ int test1() {
     mimmo::PropagateScalarField * prop = new mimmo::PropagateScalarField();
     prop->setName("test00002_PropagateScalarField");
     prop->setGeometry(mesh);
-    prop->addDirichletBoundarySurface(boundary);
+    prop->addDirichletBoundaryPatch(boundary);
     prop->addDirichletConditions(&bc_surf_field);
     prop->setDamping(false);
     prop->setPlotInExecution(true);

--- a/test/propagators/test_propagators_00003.cpp
+++ b/test/propagators/test_propagators_00003.cpp
@@ -231,7 +231,7 @@ int test1() {
     mimmo::PropagateVectorField * prop3D = new mimmo::PropagateVectorField();
     prop3D->setName("test00003_PropagateVectorField");
     prop3D->setGeometry(mesh);
-    prop3D->addDirichletBoundarySurface(bDIR);
+    prop3D->addDirichletBoundaryPatch(bDIR);
     prop3D->addDirichletConditions(&bc_surf_3Dfield);
     prop3D->addSlipBoundarySurface(bSLIP);
     prop3D->addSlipReferenceSurface(bSLIP);


### PR DESCRIPTION
This pull allows to impose a propagation problem through PropagateField block on surface meshes.

Main changes and new features:

- overloading of squeeze method in MimmoPiercedVector
- activation of bulk surface mesh as geometry of Propagate(Scalr/Vector)Field
- change of interface method to set dirichlet boundary patch (deprecated old interface set method)

Starting from #151 

Compiled with https://github.com/optimad/bitpit/commit/2ae49a8e00da488411ddb36a140505d4761e6d7e