### PR TITLE
Manipulators: add input filter field to apply block and apply filter only block

### DIFF
--- a/src/manipulators/Apply.hpp
+++ b/src/manipulators/Apply.hpp
@@ -38,7 +38,13 @@ namespace mimmo{
  *    a pin linking or set by the user, i.e. one has to use setInput method to set
  *    the displacements to be applied to the geometry.
  *    The displacements can be isotropically scaled by setting a scaling factor.
+ *    The displacements can be passed as scalar field. In this case the scalar field is used as magnitude
+ *    of a displacements field with direction along the normal of the surface on each vertex.
+ *    The Apply block allows to pass a scalar filter field; the filter field is applied to the
+ *    displacements field before the geometry deformation.
+ *
  *    After the execution of an object Apply, the original geometry will be modified.
+ *    The resulting deformation field is provided as output of the block.
  *
  * \n
  * Ports available in Apply Class :
@@ -50,12 +56,14 @@ namespace mimmo{
      | <B>PortType</B>   | <B>variable/function</B>  |<B>DataType</B> |
      | M_GDISPLS | setInput          | (MC_SCALAR,MD_MPVECARR3FLOAT_) |
      | M_SCALARFIELD | setScalarInput    | (MC_SCALAR,MD_MPVECFLOAT_) |
+     | M_FILTER | setFilter    | (MC_SCALAR,MD_MPVECFLOAT_) |
      | M_GEOM    | setGeometry       | (MC_SCALAR,MD_MIMMO_) |
 
      |Port Output | | |
      |-|-|-|
      | <B>PortType</B> | <B>variable/function</B> |<B>DataType</B>  |
      | M_GEOM          | getGeometry              | (MC_SCALAR,MD_MIMMO_) |
+     | M_GDISPLS       | getOutput          | (MC_SCALAR,MD_MPVECARR3FLOAT_) |
      | M_LONGFIELD     | getAnnotatedVertices     | (MC_SCALAR,MD_MPVECLONG_) |
      | M_LONGFIELD2    | getAnnotatedCells        | (MC_SCALAR,MD_MPVECLONG_) |
 
@@ -93,6 +101,7 @@ public:
 
     void setInput(dmpvecarr3E *input);
     void setScalarInput(dmpvector1D* input);
+    void setFilter(dmpvector1D* input);
 
     void setScaling(double alpha);
 
@@ -114,6 +123,7 @@ protected:
 
     dmpvecarr3E    m_input; /**< storing vector fields of floats */
     dmpvector1D    m_scalarinput; /**< storing scalar fields of floats */
+    dmpvector1D    m_filter; /**< storing filter multiplying to the deformation field */
     double		   m_factor; /**< scaling factor of deformation field. */
     dmpvecarr3E    m_output; /**< storing vector fields of floats for output (input modified with filter and factor)*/
 
@@ -132,6 +142,7 @@ protected:
 
 REGISTER_PORT(M_GDISPLS, MC_SCALAR, MD_MPVECARR3FLOAT_, __APPLYDEFORMATION_HPP__)
 REGISTER_PORT(M_SCALARFIELD, MC_SCALAR, MD_MPVECFLOAT_, __APPLYDEFORMATION_HPP__)
+REGISTER_PORT(M_FILTER, MC_SCALAR, MD_MPVECFLOAT_, __APPLYDEFORMATION_HPP__)
 REGISTER_PORT(M_GEOM, MC_SCALAR, MD_MIMMO_, __APPLYDEFORMATION_HPP__)
 REGISTER_PORT(M_LONGFIELD, MC_SCALAR, MD_MPVECLONG_, __APPLYDEFORMATION_HPP__)
 REGISTER_PORT(M_LONGFIELD2, MC_SCALAR, MD_MPVECLONG_, __APPLYDEFORMATION_HPP__)

--- a/src/manipulators/ApplyFilter.cpp
+++ b/src/manipulators/ApplyFilter.cpp
@@ -1,0 +1,230 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  mimmo
+ *
+ *  Copyright (C) 2015-2020 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of mimmo.
+ *
+ *  mimmo is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  mimmo is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with mimmo. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+#include "ApplyFilter.hpp"
+
+namespace mimmo{
+
+/*!
+ * Default constructor of ApplyFilter
+ */
+ApplyFilter::ApplyFilter():Apply(){
+    m_name = "mimmo.ApplyFilter";
+    m_factor = std::numeric_limits<double>::max();
+};
+
+/*!
+ * Custom constructor reading xml data
+ * \param[in] rootXML reference to your xml tree section
+ */
+ApplyFilter::ApplyFilter(const bitpit::Config::Section & rootXML){
+
+	m_name = "mimmo.ApplyFilter";
+	m_factor = 1.;
+
+	std::string fallback_name = "ClassNONE";
+	std::string input = rootXML.get("ClassName", fallback_name);
+	input = bitpit::utils::string::trim(input);
+	if(input == "mimmo.ApplyFilter"){
+		absorbSectionXML(rootXML);
+	}else{
+		warningXML(m_log, m_name);
+	};
+}
+
+/*!Default destructor of ApplyFilter
+ */
+ApplyFilter::~ApplyFilter(){};
+
+/*!
+    Copy constructor of ApplyFilter.
+ */
+ApplyFilter::ApplyFilter(const ApplyFilter & other):Apply(other){
+};
+
+/*!
+ * Swap function
+ * \param[in] x object to be swapped
+ */
+void ApplyFilter::swap(ApplyFilter & x) noexcept
+{
+	Apply::swap(x);
+}
+
+/*! It builds the input/output ports of the object
+ */
+void
+ApplyFilter::buildPorts(){
+	bool built = true;
+	built = (built && createPortIn<dmpvecarr3E*, ApplyFilter>(this, &ApplyFilter::setInput, M_GDISPLS, true, 1));
+    built = (built && createPortIn<dmpvector1D*, ApplyFilter>(this, &ApplyFilter::setScalarInput, M_SCALARFIELD, true, 1));
+    built = (built && createPortIn<dmpvector1D*, ApplyFilter>(this, &ApplyFilter::setFilter, M_FILTER));
+    built = (built && createPortIn<MimmoSharedPointer<MimmoObject>, Apply>(this, &BaseManipulation::setGeometry, M_GEOM));
+
+	built = (built && createPortOut<dmpvecarr3E*, ApplyFilter>(this, &ApplyFilter::getOutput, M_GDISPLS));
+
+	m_arePortsBuilt = built;
+};
+
+
+/*!Execution command.
+ * It applies the filter field to the deformation field stored in the input of base class (casting the input
+ * for apply object to dvecarr3E). Scaling factor is applied too if passed by the user.
+ * After exec() the linked geometry is not modified.
+ */
+void
+ApplyFilter::execute(){
+
+	checkInput();
+
+	m_output = m_input;
+
+	if (m_factor != std::numeric_limits<double>::max()){
+	    for (auto & val : m_output){
+	        val *= m_factor;
+	    }
+	}
+
+};
+
+
+/*!
+ * It sets infos reading from a XML bitpit::Config::section.
+ * \param[in] slotXML bitpit::Config::Section of XML file
+ * \param[in] name   name associated to the slot
+ */
+void
+ApplyFilter::absorbSectionXML(const bitpit::Config::Section & slotXML, std::string name){
+
+	BITPIT_UNUSED(name);
+	BaseManipulation::absorbSectionXML(slotXML, name);
+
+    if(slotXML.hasOption("Scaling")){
+        std::string input = slotXML.get("Scaling");
+        input = bitpit::utils::string::trim(input);
+        double val = 1.;
+        if(!input.empty()){
+            std::stringstream ss(input);
+            ss>>val;
+        }
+        setScaling(val);
+    }
+
+};
+
+/*!
+ * It sets infos from class members in a XML bitpit::Config::section.
+ * \param[in] slotXML bitpit::Config::Section of XML file
+ * \param[in] name   name associated to the slot
+ */
+void
+ApplyFilter::flushSectionXML(bitpit::Config::Section & slotXML, std::string name){
+
+	BITPIT_UNUSED(name);
+	BaseManipulation::flushSectionXML(slotXML, name);
+
+    slotXML.set("Scaling", std::to_string(m_factor));
+
+};
+
+/*!
+ * Check if the input is related to the target geometry.
+ * Check the coherence of filter field.
+ * If not create a zero input field.
+ */
+void
+ApplyFilter::checkInput(){
+
+	bool check = false;
+	MimmoSharedPointer<MimmoObject> linked_geometry = nullptr;
+	if (m_geometry) linked_geometry = m_geometry;
+	if (m_input.size()){
+	    if (!linked_geometry){
+	        linked_geometry = m_input.getGeometry();
+	    }
+	    else{
+	        m_input.setGeometry(linked_geometry);
+	    }
+		check = m_input.getDataLocation() == mimmo::MPVLocation::POINT;
+		check = check && m_input.completeMissingData({{0.0,0.0,0.0}});
+	}
+	if (m_scalarinput.size()){
+        if (!linked_geometry){
+            linked_geometry = m_scalarinput.getGeometry();
+        }
+        else{
+            m_scalarinput.setGeometry(linked_geometry);
+        }
+		check = m_scalarinput.getDataLocation() == mimmo::MPVLocation::POINT;
+		check = check && m_scalarinput.completeMissingData(0.0);
+		if (check){
+			bitpit::SurfaceKernel* skernel = static_cast<bitpit::SurfaceKernel*>(m_scalarinput.getGeometry()->getPatch());
+			bitpit::PiercedVector<darray3E> vNormals;
+			bitpit::ConstProxyVector<long> verts;
+			std::size_t size;
+			long idN;
+			for(const auto & cell: m_scalarinput.getGeometry()->getCells()){
+				verts = cell.getVertexIds();
+				size = verts.size();
+				for(std::size_t i=0; i<size; ++i){
+					idN = verts[i];
+					if(!vNormals.exists(idN)){
+						vNormals.insert(idN, skernel->evalVertexNormal(cell.getId(), i));
+					}
+				}
+			}
+			m_input.clear();
+			for(const auto & vertex: m_scalarinput.getGeometry()->getVertices()){
+				m_input.setDataLocation(mimmo::MPVLocation::POINT);
+				m_input.setGeometry(m_scalarinput.getGeometry());
+				long id = vertex.getId();
+				m_input.insert(id, darray3E(m_scalarinput[id]*vNormals[id]));
+			}
+		}
+	}
+	if (m_filter.size()){
+	    check = m_filter.getDataLocation() == mimmo::MPVLocation::POINT;
+        // Force filter to link the geometry linked by deformation field
+	    bool geometry_check = m_filter.getGeometry() == linked_geometry;
+	    if (!geometry_check){
+	        m_filter.setGeometry(linked_geometry);
+	    }
+	    // Complete missing data force filter to 0.
+	    check = check && m_filter.completeMissingData(0.0);
+	    if (check){
+	        // ApplyFilter filter to input deformation field
+	        for (const auto & vertex : linked_geometry->getVertices()){
+	            long ID = vertex.getId();
+	            m_input[ID] *= m_filter[ID];
+	        }
+	    }
+	}
+	if (!check){
+		m_log->setPriority(bitpit::log::Verbosity::DEBUG);
+		(*m_log) << m_name + " : not valid inputs found" << std::endl;
+		throw std::runtime_error (m_name + " : not valid inputs found");
+		m_log->setPriority(bitpit::log::Verbosity::NORMAL);
+	}
+};
+
+}

--- a/src/manipulators/ApplyFilter.hpp
+++ b/src/manipulators/ApplyFilter.hpp
@@ -1,0 +1,129 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  mimmo
+ *
+ *  Copyright (C) 2015-2020 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of mimmo.
+ *
+ *  mimmo is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  mimmo is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with mimmo. If not, see <http://www.gnu.org/licenses/>.
+ *
+\*---------------------------------------------------------------------------*/
+#ifndef __APPLYFILTER_HPP__
+#define __APPLYFILTER_HPP__
+
+#include "Apply.hpp"
+
+namespace mimmo{
+/*!
+ *  \class ApplyFilterFilter
+ *  \ingroup manipulators
+ *  \brief ApplyFilterFilter is the class that applies a filter field to a deformation field defined on a geometry.
+ *
+ *    ApplyFilterFilter is derived from ApplyFilter class. It uses an input deformation field defined
+ *    on a linked geometry to apply to it an input filter field defined over the same geometry.
+ *    The scalar filter field is applied by a simple modulation of the deformation field.
+ *    The displacements can be isotropically scaled by setting a scaling factor.
+ *    The displacements can be passed as scalar field. In this case the scalar field is used as magnitude
+ *    of a displacements field with direction along the normal of the surface on each vertex.
+ *    If a geoemtry is passed through the port the resulting deformation field will be linked to the input geometry,
+ *    even if the input fields are not linked to it. If missing data are present, they are set to zero values.
+ *    The ApplyFilterFilter block applies the filter to the
+ *    displacements field without perform a geometry deformation.
+ *    After the execution, an object ApplyFilterFilter provides as result the filtered deformation field.
+ *
+ * \n
+ * Ports available in ApplyFilterFilter Class :
+ *
+ *    =========================================================
+ *
+     | Port Input | | |
+     |-|-|-|
+     | <B>PortType</B>   | <B>variable/function</B>  |<B>DataType</B> |
+     | M_GDISPLS | setInput          | (MC_SCALAR,MD_MPVECARR3FLOAT_) |
+     | M_SCALARFIELD | setScalarInput    | (MC_SCALAR,MD_MPVECFLOAT_) |
+     | M_FILTER | setFilter    | (MC_SCALAR,MD_MPVECFLOAT_) |
+     | M_GEOM    | setGeometry       | (MC_SCALAR,MD_MIMMO_) |
+
+     |Port Output | | |
+     |-|-|-|
+     | <B>PortType</B> | <B>variable/function</B> |<B>DataType</B>  |
+     | M_GDISPLS | geOutput          | (MC_SCALAR,MD_MPVECARR3FLOAT_) |
+
+ *    =========================================================
+ * \n
+ * The xml available parameters, sections and subsections are the following :
+ *
+ * Inherited from BaseManipulation:
+ * - <B>ClassName</B> : name of the class as <tt>mimmo.ApplyFilter</tt>;
+ * - <B>Priority</B>  : uint marking priority in multi-chain execution;
+ *
+ * Proper of the class:
+
+ *
+ *
+ */
+class ApplyFilter: public Apply{
+
+public:
+
+    ApplyFilter();
+    ApplyFilter(const bitpit::Config::Section & rootXML);
+
+    ~ApplyFilter();
+
+    ApplyFilter(const ApplyFilter & other);
+
+    void buildPorts();
+
+    using Apply::setScaling;
+
+    void setAnnotation(bool activate) = delete;
+    void setCellsAnnotationName(const std::string & label) = delete;
+    void setVerticesAnnotationName(const std::string & label) = delete;
+    void setAnnotationThreshold(double threshold) = delete;
+
+    void execute();
+
+    using Apply::getOutput;
+
+    MimmoPiercedVector<long> * getAnnotatedVertices() = delete;
+    MimmoPiercedVector<long> * getAnnotatedCells() = delete;
+
+    virtual void absorbSectionXML(const bitpit::Config::Section & slotXML, std::string name="");
+    virtual void flushSectionXML(bitpit::Config::Section & slotXML, std::string name="");
+
+protected:
+
+    using   Apply::m_input;         /**< storing vector fields of floats */
+    using   Apply::m_scalarinput;   /**< storing scalar fields of floats */
+    using   Apply::m_filter;        /**< storing filter multiplying to the deformation field */
+    using   Apply::m_factor;        /**< scaling factor of deformation field. */
+    using   Apply::m_output;        /**< storing vector fields of floats for output (input modified with filter and factor)*/
+
+    void swap(ApplyFilter & x) noexcept;
+    void    checkInput();
+
+};
+
+REGISTER_PORT(M_GDISPLS, MC_SCALAR, MD_MPVECARR3FLOAT_, __APPLYFILTER_HPP__)
+REGISTER_PORT(M_SCALARFIELD, MC_SCALAR, MD_MPVECFLOAT_, __APPLYFILTER_HPP__)
+REGISTER_PORT(M_FILTER, MC_SCALAR, MD_MPVECFLOAT_, __APPLYFILTER_HPP__)
+
+REGISTER(BaseManipulation, ApplyFilter, "mimmo.ApplyFilter")
+
+};
+
+#endif /* __APPLYFILTER_HPP__ */

--- a/src/manipulators/mimmo_manipulators.hpp
+++ b/src/manipulators/mimmo_manipulators.hpp
@@ -37,6 +37,7 @@
 #include "mimmo_core.hpp"
 
 #include "Apply.hpp"
+#include "ApplyFilter.hpp"
 #include "BendGeometry.hpp"
 #include "FFDLattice.hpp"
 #include "MRBF.hpp"


### PR DESCRIPTION
The developments add:

- an input to Apply block dedicated to a filter field to modulate the geometry deformation field;
- a new block (ApplyFilter) that applies a scalar filter field to a vector deformation field.

Starting from #152 

Compiled with https://github.com/optimad/bitpit/commit/2ae49a8e00da488411ddb36a140505d4761e6d7e

_Note: the ApplyFilter block can be included in a future generic class (e.g. FieldOperations) as multiplication between scalar and vector fields defined on portions of the same geometry_