### PR TITLE
IOOFOAM: fix polygonal boundary mesh

### DIFF
--- a/src/geohandlers/FVGenericSelection.cpp
+++ b/src/geohandlers/FVGenericSelection.cpp
@@ -260,6 +260,23 @@ FVGenericSelection::execute(){
     //BOUNDARY PART
     {
         livector1D vertExtracted = m_bndgeometry->getVertexFromCellList(extractedBnd);
+
+        //TO AVOID INCONSISTENCY WITH VOLUME MESH, CHECK all verts extracted are
+        // present into the volume mesh.
+        {
+            livector1D epurated_Verts;
+            epurated_Verts.reserve(vertExtracted.size());
+            bitpit::PiercedVector<bitpit::Vertex> & volv = tempVol->getVertices();
+            for(long id: vertExtracted){
+                if(volv.exists(id)) epurated_Verts.push_back(id);
+            }
+            std::swap(vertExtracted, epurated_Verts);
+
+            // last step, recover cell strictly in the pool of this new list of epurated vertices.
+            extractedBnd = m_bndgeometry->getCellFromVertexList(vertExtracted, true);
+        }
+
+
         for(const auto & idV : vertExtracted){
             tempBnd->addVertex(m_bndgeometry->getVertexCoords(idV), idV);
         }

--- a/src/geohandlers/FVMeshSelection.hpp
+++ b/src/geohandlers/FVMeshSelection.hpp
@@ -67,6 +67,7 @@ enum class FVSelectionType{
      | <B>PortType</B>   | <B>variable/function</B>  |<B>DataType</B> |
      | M_GEOM         | getVolumePatch        | (MC_SCALAR, MD_MIMMO_)  |
      | M_GEOM2        | getBoundaryPatch      | (MC_SCALAR, MD_MIMMO_)  |
+     | M_GEOM3        | getInternalBoundaryPatch | (MC_SCALAR, MD_MIMMO_)  |
 
  *    =========================================================
  *
@@ -78,6 +79,7 @@ protected:
     FVSelectionType                 m_type;      /**< Type of enum class SelectionType for selection method */
     mimmo::MimmoSharedPointer<MimmoObject>    m_volpatch;  /**< Pointer to result volume sub-patch */
     mimmo::MimmoSharedPointer<MimmoObject>    m_bndpatch;  /**< Pointer to result boundary sub-patch */
+    mimmo::MimmoSharedPointer<MimmoObject>    m_intbndpatch;  /**< Pointer to boundary internal (not shared with boundary sub-patch) to the volume selection */
     int                             m_topo;      /**< 1 = volume (default value), 2 = surface */
     bool                            m_dual;      /**< False selects w/ current set up, true gets its "negative". False is default. */
     mimmo::MimmoSharedPointer<MimmoObject>    m_bndgeometry; /**<target boundary geometry */
@@ -98,8 +100,11 @@ public:
 
     const mimmo::MimmoSharedPointer<MimmoObject>    getVolumePatch()const;
     const mimmo::MimmoSharedPointer<MimmoObject>    getBoundaryPatch()const;
+    const mimmo::MimmoSharedPointer<MimmoObject>    getInternalBoundaryPatch()const;
+
     mimmo::MimmoSharedPointer<MimmoObject>          getVolumePatch();
     mimmo::MimmoSharedPointer<MimmoObject>          getBoundaryPatch();
+    mimmo::MimmoSharedPointer<MimmoObject>          getInternalBoundaryPatch();
 
     bool    isDual();
 
@@ -157,6 +162,7 @@ protected:
      | <B>PortType</B>   | <B>variable/function</B>  |<B>DataType</B> |
      | M_GEOM         | getVolumePatch        | (MC_SCALAR, MD_MIMMO_)  |
      | M_GEOM2        | getBoundaryPatch      | (MC_SCALAR, MD_MIMMO_)  |
+     | M_GEOM3        | getInternalBoundaryPatch | (MC_SCALAR, MD_MIMMO_)  |
 
  *    ===============================================================================
  *
@@ -245,6 +251,7 @@ protected:
      | <B>PortType</B>   | <B>variable/function</B>  |<B>DataType</B> |
      | M_GEOM         | getVolumePatch        | (MC_SCALAR, MD_MIMMO_)  |
      | M_GEOM2        | getBoundaryPatch      | (MC_SCALAR, MD_MIMMO_)  |
+     | M_GEOM3        | getInternalBoundaryPatch | (MC_SCALAR, MD_MIMMO_)  |
 
  *    =========================================================
  *
@@ -336,6 +343,7 @@ protected:
      | <B>PortType</B>   | <B>variable/function</B>  |<B>DataType</B> |
      | M_GEOM         | getVolumePatch        | (MC_SCALAR, MD_MIMMO_)  |
      | M_GEOM2        | getBoundaryPatch      | (MC_SCALAR, MD_MIMMO_)  |
+     | M_GEOM3        | getInternalBoundaryPatch | (MC_SCALAR, MD_MIMMO_)  |
 
 
  *    =========================================================
@@ -393,6 +401,7 @@ protected:
 
 REGISTER_PORT(M_GEOM, MC_SCALAR, MD_MIMMO_, __FVMESHSELECTION_HPP__)
 REGISTER_PORT(M_GEOM2, MC_SCALAR, MD_MIMMO_, __FVMESHSELECTION_HPP__)
+REGISTER_PORT(M_GEOM3, MC_SCALAR, MD_MIMMO_, __FVMESHSELECTION_HPP__)
 REGISTER_PORT(M_POINT, MC_ARRAY3, MD_FLOAT, __FVMESHSELECTION_HPP__)
 REGISTER_PORT(M_AXES, MC_ARR3ARR3, MD_FLOAT, __FVMESHSELECTION_HPP__)
 REGISTER_PORT(M_SPAN, MC_ARRAY3, MD_FLOAT, __FVMESHSELECTION_HPP__)

--- a/src/ioofoam/IOOFOAM.cpp
+++ b/src/ioofoam/IOOFOAM.cpp
@@ -585,9 +585,9 @@ IOOFOAM::read(){
         long iBIT = bitpit::Interface::NULL_ID;
         std::size_t j(0);
         while(iBIT < 0 && j<sizeFList){
-            long * vconn = bitInterfaces[bitFaceList[j]].getConnect();
-            std::size_t vconnsize = bitInterfaces[bitFaceList[j]].getConnectSize();
-            std::vector<long> vListBIT(vconn, vconn+vconnsize);
+            bitpit::ConstProxyVector<long> vconn = bitInterfaces[bitFaceList[j]].getVertexIds();
+            std::size_t vconnsize = vconn.size();
+            std::vector<long> vListBIT(vconn.begin(), vconn.end());
             std::sort(vListBIT.begin(), vListBIT.end());
 
             if(std::equal(vListBIT.begin(), vListBIT.end(), vListOF.begin()) ){


### PR DESCRIPTION
this pull fixes: 
- ioofoam:IOOFOAM block reading meshes defined by polygonal/polyhedral meshes 
- geohandlers:FVSelection blocks subset extraction of bulk/boundary meshes and keep results aligned (cell of boundary subset have 1-1 correspondence with border faces of the bulk subset )
- geohandlers:FVSelection blocks exposing also _internal_ boundaries, that is those borders of the bulk extraction, not belonging to the original boundary. 