### PR TITLE
core: Add primitive block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ This library _tries_ to adhere to [Semantic Versioning](http://semver.org/).
 - added MPI parallel support for the library (I/O not completely supported in parallel)
 - added synchronization status to info and structures stored in mimmo object
 - added update method in mimmo object
+- added a block to define a primitive shape
+
 
 ### Changed
 - update MimmoGeometry to export geometry object in a unique STL file during parallel processes

--- a/src/core/Primitive.cpp
+++ b/src/core/Primitive.cpp
@@ -1,0 +1,238 @@
+/*---------------------------------------------------------------------------*\
+ *
+ *  mimmo
+ *
+ *  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+ *
+ *  -------------------------------------------------------------------------
+ *  License
+ *  This file is part of mimmo.
+ *
+ *  mimmo is free software: you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License v3 (LGPL)
+ *  as published by the Free Software Foundation.
+ *
+ *  mimmo is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+ *  License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with mimmo. If not, see <http://www.gnu.org/licenses/>.
+ *
+\ *---------------------------------------------------------------------------*/
+
+#include "Primitive.hpp"
+
+namespace mimmo{
+
+/*!
+ * Basic Constructor
+ */
+Primitive::Primitive(){
+    m_name = "mimmo.Primitive";
+};
+
+/*!
+ * Custom constructor reading xml data
+ * \param[in] rootXML reference to your xml tree section
+ */
+Primitive::Primitive(const bitpit::Config::Section & rootXML){
+    m_name = "mimmo.Primitive";
+    std::string fallback_name = "ClassNONE";
+    std::string input = rootXML.get("ClassName", fallback_name);
+    input = bitpit::utils::string::trim(input);
+    if(input == "mimmo.Primitive"){
+        absorbSectionXML(rootXML);
+    }else{
+        warningXML(m_log, m_name);
+    };
+}
+
+/*! Destructor */
+Primitive::~Primitive(){};
+
+/*! Copy Constructor
+ *\param[in] other Primitive object
+ */
+Primitive::Primitive(const Primitive & other):BaseManipulation(other), UStructMesh(other){
+};
+
+/*!
+ * Swap function.
+ * \param[in] x object to be swapped
+ */
+void Primitive::swap(Primitive & x) noexcept
+{
+    UStructMesh::swap(x);
+    BaseManipulation::swap(x);
+}
+
+/*!
+ * It builds the input/output ports of the object
+ */
+void Primitive::buildPorts(){
+
+    bool built = true;
+    built = (built && createPortIn<darray3E, Primitive>(this, &mimmo::Primitive::setInfLimits, M_INFLIMITS));
+    built = (built && createPortIn<dmatrix33E, Primitive>(this, &mimmo::Primitive::setRefSystem, M_AXES));
+    built = (built && createPortIn<darray3E, Primitive>(this, &mimmo::Primitive::setSpan, M_SPAN));
+    built = (built && createPortIn<darray3E, Primitive>(this, &mimmo::Primitive::setOrigin, M_POINT));
+    built = (built && createPortIn<mimmo::ShapeType, Primitive>(this, &mimmo::Primitive::setShape, M_SHAPE));
+    built = (built && createPortIn<const BasicShape *, Primitive>(this, &mimmo::Primitive::setShape, M_COPYSHAPE));
+    built = (built && createPortIn<int, Primitive>(this, &mimmo::Primitive::setShape, M_SHAPEI));
+
+    // creating output ports
+    built = (built && createPortOut<BasicShape *, Primitive>(this, &mimmo::Primitive::getShape, M_COPYSHAPE));
+
+    m_arePortsBuilt = built;
+};
+
+/*!
+ * Clean every setting and data hold by the class
+ */
+void Primitive::clearPrimitive(){
+    clear(); //base manipulation stuff clear
+    clearMesh(); // structured mesh cleaned
+};
+
+/*!
+ * Execute your object. Currently do nothing.
+ */
+void
+Primitive::execute(){
+};
+
+/*!
+ * It sets infos reading from a XML bitpit::Config::section.
+ * \param[in] slotXML bitpit::Config::Section of XML file
+ * \param[in] name   name associated to the slot
+ */
+void Primitive::absorbSectionXML(const bitpit::Config::Section & slotXML, std::string name){
+
+    BITPIT_UNUSED(name);
+
+    BaseManipulation::absorbSectionXML(slotXML, name);
+
+    if(slotXML.hasOption("Shape")){
+        std::string input = slotXML.get("Shape");
+        input = bitpit::utils::string::trim(input);
+
+        if(input == "CYLINDER"){
+            setShape(ShapeType::CYLINDER);
+        }else if(input =="SPHERE"){
+            setShape(ShapeType::SPHERE);
+        }else if(input =="WEDGE"){
+            setShape(ShapeType::WEDGE);
+        }else{
+            setShape(ShapeType::CUBE);
+        }
+    };
+
+    if(slotXML.hasOption("Origin")){
+        std::string input = slotXML.get("Origin");
+        input = bitpit::utils::string::trim(input);
+        darray3E temp = {{0.0,0.0,0.0}};
+        if(!input.empty()){
+            std::stringstream ss(input);
+            for(auto &val : temp) ss>>val;
+        }
+        setOrigin(temp);
+    };
+
+    if(slotXML.hasOption("Span")){
+        std::string input = slotXML.get("Span");
+        input = bitpit::utils::string::trim(input);
+        darray3E temp = {{0.0,0.0,0.0}};
+        if(!input.empty()){
+            std::stringstream ss(input);
+            for(auto &val : temp) ss>>val;
+        }
+        setSpan(temp);
+    };
+
+    if(slotXML.hasSection("RefSystem")){
+        const bitpit::Config::Section & rfXML = slotXML.getSection("RefSystem");
+        std::string rootAxis = "axis";
+        std::string axis;
+        dmatrix33E temp;
+        temp[0].fill(0.0); temp[0][0] = 1.0;
+        temp[1].fill(0.0); temp[1][1] = 1.0;
+        temp[2].fill(0.0); temp[2][2] = 1.0;
+        for(int i=0; i<3; ++i){
+            axis = rootAxis + std::to_string(i);
+            std::string input = rfXML.get(axis);
+            input = bitpit::utils::string::trim(input);
+            if(!input.empty()){
+                std::stringstream ss(input);
+                for(auto &val : temp[i]) ss>>val;
+            }
+        }
+        setRefSystem(temp);
+    };
+
+    if(slotXML.hasOption("InfLimits")){
+        std::string input = slotXML.get("InfLimits");
+        input = bitpit::utils::string::trim(input);
+        darray3E temp = {{0.0,0.0,0.0}};
+        if(!input.empty()){
+            std::stringstream ss(input);
+            for(auto &val : temp) ss>>val;
+        }
+        setInfLimits(temp);
+    };
+
+}
+
+/*!
+ * It sets infos from class members in a XML bitpit::Config::section.
+ * \param[in] slotXML bitpit::Config::Section of XML file
+ * \param[in] name   name associated to the slot
+ */
+void Primitive::flushSectionXML(bitpit::Config::Section & slotXML, std::string name){
+
+    BITPIT_UNUSED(name);
+
+    BaseManipulation::flushSectionXML(slotXML, name);
+
+    std::string towrite = "CUBE";
+
+    if(getShapeType() == ShapeType::CYLINDER){
+        towrite = "CYLINDER";
+    } else if(getShapeType() == ShapeType::SPHERE){
+        towrite = "SPHERE";
+    } else if(getShapeType() == ShapeType::WEDGE){
+        towrite = "WEDGE";
+    }
+    slotXML.set("Shape", towrite);
+
+    {
+        std::stringstream ss;
+        ss<<std::scientific<<getOrigin()[0]<<'\t'<<getOrigin()[1]<<'\t'<<getOrigin()[2];
+        slotXML.set("Origin", ss.str());
+    }
+
+    {
+        std::stringstream ss;
+        ss<<std::scientific<<getSpan()[0]<<'\t'<<getSpan()[1]<<'\t'<<getSpan()[2];
+        slotXML.set("Span", ss.str());
+    }
+
+    {
+        auto rs = getRefSystem();
+        bitpit::Config::Section & rsXML = slotXML.addSection("RefSystem");
+        std::string rootAxis = "axis";
+        std::string localAxis;
+        int counter=0;
+        for(auto &axis : rs){
+            localAxis = rootAxis+std::to_string(counter);
+            std::stringstream ss;
+            ss<<std::scientific<<axis[0]<<'\t'<<axis[1]<<'\t'<<axis[2];
+            rsXML.set(localAxis, ss.str());
+            ++counter;
+        }
+    }
+
+};
+
+}

--- a/src/core/Primitive.hpp
+++ b/src/core/Primitive.hpp
@@ -1,0 +1,170 @@
+/*---------------------------------------------------------------------------*\
+*
+*  mimmo
+*
+*  Copyright (C) 2015-2021 OPTIMAD engineering Srl
+*
+*  -------------------------------------------------------------------------
+*  License
+*  This file is part of mimmo.
+*
+*  mimmo is free software: you can redistribute it and/or modify it
+*  under the terms of the GNU Lesser General Public License v3 (LGPL)
+*  as published by the Free Software Foundation.
+*
+*  mimmo is distributed in the hope that it will be useful, but WITHOUT
+*  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+*  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+*  License for more details.
+*
+*  You should have received a copy of the GNU Lesser General Public License
+*  along with mimmo. If not, see <http://www.gnu.org/licenses/>.
+*
+\*---------------------------------------------------------------------------*/
+#ifndef __PRIMITIVE_HPP__
+#define __PRIMITIVE_HPP__
+
+#include "BaseManipulation.hpp"
+#include "BasicShapes.hpp"
+#include "BasicMeshes.hpp"
+
+namespace mimmo{
+
+/*!
+ * \class Primitive
+ * \ingroup core
+ * \brief Primitive object generation.
+ *
+ *
+ * Basically, it builds an elemental 3D shape.
+ * The available shapes are: box, sphere, cylinder, wedge.
+ * A non-complete primitive can be defined by using custom span dimensions.
+ *
+ *
+ * Ports available in Primitive class:
+ *
+ * =========================================================
+ *
+ *
+ *  |Port Input  | | |
+    |-|-|-|
+    |<B>PortType</B>|<B>variable/function</B>|<B>DataType</B>|
+    | M_DIMENSION | setDimension                          | (MC_ARRAY3, MD_INT)         |
+    | M_INFLIMITS | setInfLimits                          | (MC_ARRAY3, MD_FLOAT)       |
+    | M_AXES      | setRefSystem                          | (MC_ARR3ARR3, MD_FLOAT)     |
+    | M_SPAN      | setSpan                               | (MC_ARRAY3, MD_FLOAT)       |
+    | M_POINT     | setOrigin                             | (MC_ARRAY3, MD_FLOAT)       |
+    | M_SHAPE     | setShape(mimmo::ShapeType)            | (MC_SCALAR, MD_SHAPET)      |
+    | M_SHAPEI    | setShape(int)                         | (MC_SCALAR, MD_INT)         |
+
+
+    | Port Output | | |
+    |-|-|-|
+    |<B>PortType</B>|<B>variable/function</B>|<B>DataType</B>|
+    | M_COPYSHAPE | getShape          | (MC_SCALAR, MD_SHAPE_)    |
+
+* =========================================================
+*
+* The xml available parameters, sections and subsections  are the following:
+*
+*Inherited from BaseManipulation:
+* - <B>ClassName</B>: name of the class as <tt>mimmo.Primitive</tt>;
+* - <B>Priority</B>: uint marking priority in multi-chain execution;
+* - <B>PlotInExecution</B>: boolean 0/1 print optional results of the class.
+* - <B>OutputPlot</B>: target directory for optional results writing.
+*
+*Proper of the class:
+* - <B>Shape</B>: type of basic shape for your lattice. Available choice are CUBE, CYLINDER,SPHERE,WEDGE
+* - <B>Origin</B>: 3D point marking the shape barycenter
+* - <B>Span</B>: span dimensions of your shape (width-height-depth for CUBE,
+                baseRadius-azimuthalspan-height for CYLINDER,
+                radius-azimuthalspan-polarspan for SPHERE,
+                triangle width-triangle height-depth for WEDGE)
+* - <B>RefSystem</B>: axes of current shape reference system. written in XML as:\n\n
+            <tt> <B>\<RefSystem\> </B> \n
+            &nbsp;&nbsp;&nbsp;<B>\<axis0\></B> 1.0 0.0 0.0 <B>\</axis0\></B> \n
+            &nbsp;&nbsp;&nbsp;<B>\<axis1\></B> 0.0 1.0 0.0 <B>\</axis1\></B> \n
+            &nbsp;&nbsp;&nbsp;<B>\<axis2\></B> 0.0 0.0 1.0 <B>\</axis2\></B> \n
+            <B>\</RefSystem\></B> </tt>\n\n
+* - <B>InfLimits</B>: inferior limits for shape coordinates (meaningful only for CYLINDER AND SPHERE curvilinear coordinates)
+*
+*/
+class Primitive: public BaseManipulation, public UStructMesh {
+
+public:
+    Primitive();
+    Primitive(const bitpit::Config::Section & rootXML);
+    virtual ~Primitive();
+
+    //copy operators/constructors
+    Primitive(const Primitive & other);
+
+    void        buildPorts();
+    void        clearPrimitive();
+
+    void        execute();
+
+    virtual void absorbSectionXML(const bitpit::Config::Section & slotXML, std::string name = "");
+    virtual void flushSectionXML(bitpit::Config::Section & slotXML, std::string name= "");
+
+    darray3E                getSpacing() = delete;
+    iarray3E                getDimension() = delete;
+    darray3E                getLocalCCell(int) = delete;
+    darray3E                getLocalCCell(int, int, int) = delete;
+    darray3E                getLocalPoint(int) = delete;
+    darray3E                getLocalPoint(int, int, int) = delete;
+    darray3E                getGlobalCCell(int) = delete;
+    darray3E                getGlobalCCell(int, int, int) = delete;
+    darray3E                getGlobalPoint(int) = delete;
+    darray3E                getGlobalPoint(int, int, int) = delete;
+    ivector1D               getCellNeighs(int) = delete;
+    ivector1D               getCellNeighs(int, int, int) = delete;
+    dvecarr3E               getLocalCoords() = delete;
+    dvecarr3E               getGlobalCoords() = delete;
+    dvecarr3E               getGlobalCellCentroids() = delete;
+    dvecarr3E               getLocalCellCentroids() = delete;
+    void    setDimension(ivector1D dim) = delete;
+    void    setDimension(iarray3E dim) = delete;
+    void    locateCellByPoint(darray3E & point, int &i, int &j, int &k) = delete;
+    void    locateCellByPoint(dvector1D & point, int &i, int &j, int &k) = delete;
+    int     accessCellIndex(int i, int j, int k) = delete;
+    void    accessCellIndex(int N_, int &i, int &j, int &k) = delete;
+    int     accessPointIndex(int i, int j, int k) = delete;
+    void    accessPointIndex(int N_, int &i, int &j, int &k) = delete;
+    double      interpolateCellData(darray3E & point, dvector1D & celldata) = delete;
+    int         interpolateCellData(darray3E & point, ivector1D & celldata) = delete;
+    darray3E    interpolateCellData(darray3E & point, dvecarr3E & celldata) = delete;
+    double      interpolatePointData(darray3E & point, dvector1D & pointdata) = delete;
+    int         interpolatePointData(darray3E & point, ivector1D & pointdata) = delete;
+    darray3E    interpolatePointData(darray3E & point, dvecarr3E & pointdata) = delete;
+    void        plotCloud( std::string & , std::string, int , bool, const ivector1D & labels, dvecarr3E * extPoints=nullptr) = delete;
+    void        plotCloudScalar(std::string, std::string , int, bool, dvector1D & data) = delete;
+    void        plotGrid(std::string &, std::string , int, bool, const ivector1D & labels, dvecarr3E * extPoints=nullptr) = delete;
+    void        plotGridScalar(std::string, std::string , int, bool, dvector1D & data) = delete;
+    bool        isBuilt() = delete;
+
+protected:
+    void            swap(Primitive & ) noexcept;
+//    virtual void    plotOptionalResults();
+
+    void        resizeMesh() = delete;
+    void        destroyNodalStructure() = delete;
+    void        reshapeNodalStructure() = delete;
+
+
+};
+
+REGISTER_PORT(M_DIMENSION, MC_ARRAY3, MD_INT, __PRIMITIVE_HPP__)
+REGISTER_PORT(M_INFLIMITS, MC_ARRAY3, MD_FLOAT, __PRIMITIVE_HPP__)
+REGISTER_PORT(M_AXES, MC_ARR3ARR3, MD_FLOAT, __PRIMITIVE_HPP__)
+REGISTER_PORT(M_SPAN, MC_ARRAY3, MD_FLOAT, __PRIMITIVE_HPP__)
+REGISTER_PORT(M_POINT, MC_ARRAY3, MD_FLOAT, __PRIMITIVE_HPP__)
+REGISTER_PORT(M_SHAPE, MC_SCALAR, MD_SHAPET, __PRIMITIVE_HPP__)
+REGISTER_PORT(M_COPYSHAPE, MC_SCALAR, MD_SHAPE_, __PRIMITIVE_HPP__)
+REGISTER_PORT(M_SHAPEI, MC_SCALAR, MD_INT, __PRIMITIVE_HPP__)
+
+REGISTER(BaseManipulation, Primitive, "mimmo.Primitive")
+
+}
+
+#endif /* __PRIMITIVE_HPP__ */

--- a/src/core/mimmo_core.hpp
+++ b/src/core/mimmo_core.hpp
@@ -50,5 +50,6 @@
 #include "VTUGridWriterASCII.hpp"
 #include "Module.hpp"
 #include "MimmoSharedPointer.hpp"
+#include "Primitive.hpp"
 
 #endif


### PR DESCRIPTION
The pull adds a light primitive block useful to define a primitive shape without undesired advanced methods and functionalities of UStructMesh class.

Compiled with https://github.com/optimad/bitpit/commit/1d9898a7210e3eead7d37b41384b9a60f087e5b4